### PR TITLE
[Chore] Fixed bugs

### DIFF
--- a/configs/gymnasium_dqn.yaml
+++ b/configs/gymnasium_dqn.yaml
@@ -7,8 +7,8 @@ env:
   device: cpu
 
 collector:
-  frames_per_batch: 128
-  total_frames: 50000
+  frames_per_batch: 200
+  total_frames: 1000000
   no_cuda_sync: false
 
 model:

--- a/configs/mogymnasium_ppo.yaml
+++ b/configs/mogymnasium_ppo.yaml
@@ -7,8 +7,8 @@ env:
   device: cpu
 
 collector:
-  frames_per_batch: 2048
-  total_frames: 200000
+  frames_per_batch: 2000
+  total_frames: 1000000
   no_cuda_sync: false
 
 model:

--- a/configs/vmas_ppo.yaml
+++ b/configs/vmas_ppo.yaml
@@ -11,7 +11,7 @@ env:
 
 collector:
   frames_per_batch: 60000
-  total_frames: 10000000
+  total_frames: 12000000
   no_cuda_sync: false
 
 model:

--- a/configs/vmas_qmix.yaml
+++ b/configs/vmas_qmix.yaml
@@ -11,7 +11,7 @@ env:
 
 collector:
   frames_per_batch: 6000
-  total_frames: 10000000
+  total_frames: 12000000
   no_cuda_sync: false
 
 model:

--- a/scripts/vmas_ppo.py
+++ b/scripts/vmas_ppo.py
@@ -238,14 +238,14 @@ def make_trainer(cfg: DictConfig, env: TransformedEnv) -> tuple[PPOTrainer, Logg
     )
 
     trainer.register_op(
-        dest="pre_epoch",
+        dest="batch_process",
         op=ExpandSharedNextKeysHook(
             group=group,
             key_names=("done", "terminated"),
         ),
     )
     trainer.register_op(
-        dest="pre_epoch",
+        dest="batch_process",
         op=MultiAgentGAEHook(
             loss_module=loss_module,
             gamma=cfg.loss.gamma,

--- a/scripts/vmas_qmix.py
+++ b/scripts/vmas_qmix.py
@@ -74,13 +74,13 @@ def make_modules(
         out_keys=[(group, "action_value")],
     )
     value_module = QValueModule(
+        action_space="categorical",
         action_value_key=(group, "action_value"),
         out_keys=[
             env.action_key,
             (group, "action_value"),
             (group, "chosen_action_value"),
         ],
-        spec=env.full_action_spec_unbatched,
     )
     qnet = SafeSequential(actor_module, value_module)
 
@@ -132,6 +132,7 @@ def make_trainer(cfg: DictConfig, env: TransformedEnv) -> tuple[QmixTrainer, Log
         mixer,
         delay_value=cfg.loss.delay_value,
         loss_function=cfg.loss.loss_function,
+        action_space="categorical",
     )
     loss_module.set_keys(
         reward="reward",

--- a/src/xdrl/trainer_hooks/logging.py
+++ b/src/xdrl/trainer_hooks/logging.py
@@ -185,22 +185,26 @@ class LoggingCollectionMetricsHook(TrainerHookBase):
 
 
 class LoggingTrainingMetricsHook(TrainerHookBase):
-    """Reduces training tensors and mirrors them under the ``train/`` namespace."""
+    """Logs reduced optimization metrics under the ``train/`` namespace."""
 
     def __init__(self, group: str = "agents") -> None:
         self.group = group
 
-    def __call__(self, _sub_batch: TensorDictBase, losses_td: TensorDictBase) -> TensorDictBase:
-        for key, value in list(losses_td.items()):
-            if isinstance(value, torch.Tensor) and value.numel() > 1:
+    def __call__(self, _optim_steps: int, average_losses: TensorDictBase | None) -> dict[str, float]:
+        if average_losses is None:
+            return {}
+
+        out: dict[str, float] = {}
+        for key, value in average_losses.items():
+            if not isinstance(value, torch.Tensor):
+                continue
+            if value.numel() > 1:
                 value = value.mean()
-                losses_td.set(key, value)
-            if isinstance(value, torch.Tensor):
-                losses_td.set(f"train/{self.group}/{key}", value)
-        return losses_td
+            out[f"train/{self.group}/{key}"] = _as_float(value)
+        return out
 
     def register(self, trainer: Trainer, name: str = "logging_training_metrics") -> None:
-        trainer.register_op("process_loss", self)
+        trainer.register_op("post_optim_complete_log", self)
         trainer.register_module(name, self)
 
     def state_dict(self) -> dict[str, Any]:
@@ -637,7 +641,7 @@ class LoggingHookSet:
 
     def register(self, trainer: Trainer) -> None:
         trainer.register_op("batch_process", self._timers_start)
-        trainer.register_op("process_loss", self.training_hook)
+        trainer.register_op("post_optim_complete_log", self.training_hook)
 
         trainer.register_op("pre_steps_log", self.counters_hook)
         trainer.register_op("pre_steps_log", self.collection_hook)

--- a/src/xdrl/trainer_hooks/logging.py
+++ b/src/xdrl/trainer_hooks/logging.py
@@ -195,12 +195,14 @@ class LoggingTrainingMetricsHook(TrainerHookBase):
             return {}
 
         out: dict[str, float] = {}
-        for key, value in average_losses.items():
+        for key, value in list(average_losses.items()):
             if not isinstance(value, torch.Tensor):
                 continue
-            if value.numel() > 1:
-                value = value.mean()
-            out[f"train/{self.group}/{key}"] = _as_float(value)
+            scalar = value.mean() if value.numel() > 1 else value.reshape(())
+            average_losses.set(key, scalar)
+            namespaced_key = f"train/{self.group}/{key}"
+            average_losses.set(namespaced_key, scalar)
+            out[namespaced_key] = _as_float(scalar)
         return out
 
     def register(self, trainer: Trainer, name: str = "logging_training_metrics") -> None:


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #?
- #?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes logging aggregation and action handling in multi‑agent trainers, and moves key hooks to the correct stages. Also updates default training lengths to prevent premature stops.

- **Bug Fixes**
  - Run shared-key expansion and GAE during batch processing (not pre‑epoch) in `vmas_ppo` to compute dones/advantages per batch.
  - Log optimization metrics at `post_optim_complete_log`; reduce tensors to scalars, mirror under `train/<group>/...`, return a flat dict of floats, and write scalars back into the losses tensor dict.
  - Update timer/training hook registrations to the new logging stage.
  - Treat actions as categorical in `vmas_qmix` value and loss modules; remove obsolete spec wiring to fix discrete action selection and chosen action values.
  - Correct default config numbers: `gymnasium_dqn` (frames_per_batch 200, total_frames 1,000,000), `mogymnasium_ppo` (frames_per_batch 2,000, total_frames 1,000,000), `vmas_ppo`/`vmas_qmix` (total_frames 12,000,000).

<sup>Written for commit 85689c9413c0f584686ab58f2361a970adac2c6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

