### PR TITLE
Define TorchRL model schema contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     environment: ci
     timeout-minutes: 10
     steps:
@@ -35,4 +35,14 @@ jobs:
         just test-assets
     - name: Run tests
       run: |
-        just tests
+        uv run pytest tests --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=50 \
+          --junitxml=test-results.xml -s -v
+    - name: Upload test artifacts
+      if: ${{ matrix.python-version == '3.11' && always() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-python-3.11
+        path: |
+          coverage.xml
+          test-results.xml
+        if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+test-results.xml
 coverage.xml
 *.cover
 *.py,cover

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Xmaster6y/xdrl/blob/main/LICENSE)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![python versions](https://img.shields.io/badge/python-3.11%20|%203.12-blue)](https://www.python.org/downloads/)
+[![python versions](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-blue)](https://www.python.org/downloads/)
 ![ci](https://github.com/Xmaster6y/xdrl/actions/workflows/ci.yml/badge.svg)
 ![publish](https://github.com/Xmaster6y/xdrl/actions/workflows/publish.yml/badge.svg)
 

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -1,0 +1,39 @@
+Architecture: TorchRL-native model contracts
+============================================
+
+``xdrl.types`` describes RL model roles and TensorDict I/O contracts without
+introducing a second data container or a parallel specification hierarchy.
+
+Mapping to TorchRL and TensorDict
+---------------------------------
+
+=============================  ===============================================
+xdrl type                      Reused or refined upstream type
+=============================  ===============================================
+``TensorDictKey``              ``tensordict.utils.NestedKey``
+``TensorDictSchema`` input     ``tensordict.TensorDictBase``
+``KeySchema.spec``             ``torchrl.data.TensorSpec`` (including Composite)
+``TorchRLModule``              ``tensordict.nn.TensorDictModuleBase``
+``ContractModule``             Structural interface for TorchRL-compatible modules
+=============================  ===============================================
+
+``ModelRole`` makes actor, critic, value, loss, encoder, mixer, and world-model
+intent explicit. ``KeyRole`` records state, observation, action, reward,
+termination, log-probability, distribution-parameter, value, and feature keys.
+All key paths remain native nested keys, for example
+``("agents", "action")``.
+
+Validation boundaries
+---------------------
+
+Static annotations specify module roles, nested keys, and the
+``ContractModule`` interface. Construction-time checks reject duplicate key
+paths. Runtime ``validate_module`` checks a required input schema before a
+call, then produced keys afterwards; errors include the nested key path and
+the observed shape. ``BatchSemantics`` names leading TensorDict dimensions
+separately from the feature shape held by a ``TensorSpec``.
+
+Use runtime validation at public composition boundaries, not in inner training
+loops. TorchRL's probabilistic actors, value operators, loss modules, and
+exploration modules continue to own their native construction and behavior;
+the contract is only an optional annotation and validation boundary.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@
     start
     features
     tutorials
+    architecture
     api/index
     About <about>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 [project.urls]

--- a/src/xdrl/types.py
+++ b/src/xdrl/types.py
@@ -17,8 +17,8 @@ from tensordict.nn import TensorDictModuleBase
 from tensordict.utils import NestedKey
 from torchrl.data import TensorSpec
 
+#: A TensorDict key, including nested paths such as ``("agents", "action")``.
 TensorDictKey: TypeAlias = NestedKey
-"""A TensorDict key, including nested paths such as ``("agents", "action")``."""
 
 
 class ModelRole(str, Enum):
@@ -155,8 +155,8 @@ def validate_module(module: ContractModule, tensordict: TensorDictBase) -> Tenso
     return result
 
 
+#: Concrete TorchRL TensorDict module base, re-exported for type annotations.
 TorchRLModule: TypeAlias = TensorDictModuleBase
-"""Concrete TorchRL TensorDict module base, re-exported for type annotations."""
 
 
 def _display_key(key: TensorDictKey) -> str:
@@ -166,6 +166,8 @@ def _display_key(key: TensorDictKey) -> str:
 def _matches_spec(spec: TensorSpec, value: torch.Tensor) -> bool:
     """Check feature shape before applying a TorchRL spec membership constraint."""
     feature_shape = spec.shape
-    if feature_shape and (len(value.shape) < len(feature_shape) or value.shape[-len(feature_shape) :] != feature_shape):
+    if feature_shape and (
+        len(value.shape) < len(feature_shape) or value.shape[-len(feature_shape) :] != feature_shape
+    ):
         return False
     return bool(spec.is_in(value))

--- a/src/xdrl/types.py
+++ b/src/xdrl/types.py
@@ -1,0 +1,171 @@
+"""TorchRL-native contracts for RL model roles and TensorDict schemas.
+
+The types in this module describe interfaces around TorchRL objects.  They do
+not introduce a container or a spec hierarchy: data remains a
+``TensorDictBase`` and value constraints remain TorchRL ``TensorSpec`` objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, TypeAlias, runtime_checkable
+
+import torch
+from tensordict import TensorDictBase
+from tensordict.nn import TensorDictModuleBase
+from tensordict.utils import NestedKey
+from torchrl.data import TensorSpec
+
+TensorDictKey: TypeAlias = NestedKey
+"""A TensorDict key, including nested paths such as ``("agents", "action")``."""
+
+
+class ModelRole(str, Enum):
+    """The public role a TorchRL module plays in an RL system."""
+
+    ACTOR = "actor"
+    CRITIC = "critic"
+    VALUE = "value"
+    LOSS = "loss"
+    ENCODER = "encoder"
+    MIXER = "mixer"
+    WORLD_MODEL = "world_model"
+
+
+class KeyRole(str, Enum):
+    """Semantic role of a key without changing its TensorDict representation."""
+
+    STATE = "state"
+    OBSERVATION = "observation"
+    ACTION = "action"
+    REWARD = "reward"
+    TERMINATION = "termination"
+    LOG_PROBABILITY = "log_probability"
+    DISTRIBUTION_PARAMETER = "distribution_parameter"
+    VALUE = "value"
+    FEATURE = "feature"
+
+
+class KeyPresence(str, Enum):
+    """Whether a contract consumes, produces, or optionally uses a key."""
+
+    REQUIRED = "required"
+    PRODUCED = "produced"
+    OPTIONAL = "optional"
+
+
+@dataclass(frozen=True, slots=True)
+class BatchSemantics:
+    """Meaning of leading TensorDict dimensions, independent of feature shape.
+
+    ``dimensions`` names every leading dimension in order.  Feature dimensions
+    are represented only by a key's TorchRL ``TensorSpec``.
+    """
+
+    dimensions: tuple[str, ...] = ()
+
+    def validate(self, batch_size: torch.Size) -> None:
+        """Raise when a TensorDict does not have the declared number of batch dims."""
+        if len(batch_size) != len(self.dimensions):
+            raise SchemaValidationError(
+                "batch dimensions mismatch: "
+                f"schema declares {self.dimensions!r}, TensorDict has batch_size={tuple(batch_size)!r}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class KeySchema:
+    """A semantic TensorDict key refined by an optional TorchRL spec."""
+
+    key: TensorDictKey
+    role: KeyRole
+    presence: KeyPresence
+    spec: TensorSpec | None = None
+
+
+class SchemaValidationError(ValueError):
+    """A TensorDict violates a model schema contract."""
+
+
+_MISSING = object()
+
+
+@dataclass(frozen=True, slots=True)
+class TensorDictSchema:
+    """I/O schema for a role, reusing nested keys and TorchRL specs directly."""
+
+    keys: tuple[KeySchema, ...]
+    batch: BatchSemantics = field(default_factory=BatchSemantics)
+
+    def __post_init__(self) -> None:
+        duplicates = [entry.key for entry in self.keys if sum(item.key == entry.key for item in self.keys) > 1]
+        if duplicates:
+            raise ValueError(f"schema contains duplicate keys: {duplicates!r}")
+
+    def validate_inputs(self, tensordict: TensorDictBase) -> None:
+        """Validate required and optional consumed keys in ``tensordict``."""
+        self._validate(tensordict, {KeyPresence.REQUIRED, KeyPresence.OPTIONAL})
+
+    def validate_outputs(self, tensordict: TensorDictBase) -> None:
+        """Validate produced keys in ``tensordict`` after a module call."""
+        self._validate(tensordict, {KeyPresence.PRODUCED})
+
+    def _validate(self, tensordict: TensorDictBase, presences: set[KeyPresence]) -> None:
+        self.batch.validate(tensordict.batch_size)
+        for entry in self.keys:
+            if entry.presence not in presences:
+                continue
+            value = tensordict.get(entry.key, _MISSING)
+            path = _display_key(entry.key)
+            if value is _MISSING:
+                if entry.presence is KeyPresence.REQUIRED or entry.presence is KeyPresence.PRODUCED:
+                    raise SchemaValidationError(f"missing {entry.presence.value} key at {path}")
+                continue
+            if not isinstance(value, torch.Tensor):
+                raise SchemaValidationError(f"key at {path} must contain a torch.Tensor, got {type(value).__name__}")
+            if entry.spec is not None and not _matches_spec(entry.spec, value):
+                raise SchemaValidationError(
+                    f"spec mismatch at {path}: got shape={tuple(value.shape)!r}, expected feature shape="
+                    f"{tuple(entry.spec.shape)!r} and spec={entry.spec!r}"
+                )
+
+
+@runtime_checkable
+class ContractModule(Protocol):
+    """TorchRL module interface annotated with explicit input and output schemas."""
+
+    role: ModelRole
+    input_schema: TensorDictSchema
+    output_schema: TensorDictSchema
+
+    def __call__(self, tensordict: TensorDictBase, *args: object, **kwargs: object) -> TensorDictBase: ...
+
+
+def validate_module(module: ContractModule, tensordict: TensorDictBase) -> TensorDictBase:
+    """Validate a contract module's input and output around one TensorDict call.
+
+    ``TensorDictModuleBase`` is deliberately not required: probabilistic actors,
+    loss modules, and user modules may expose compatible TensorDict call
+    interfaces without sharing that concrete base class.
+    """
+    module.input_schema.validate_inputs(tensordict)
+    result = module(tensordict)
+    module.output_schema.validate_outputs(result)
+    return result
+
+
+TorchRLModule: TypeAlias = TensorDictModuleBase
+"""Concrete TorchRL TensorDict module base, re-exported for type annotations."""
+
+
+def _display_key(key: TensorDictKey) -> str:
+    return "/".join(key) if isinstance(key, tuple) else key
+
+
+def _matches_spec(spec: TensorSpec, value: torch.Tensor) -> bool:
+    """Check feature shape before applying a TorchRL spec membership constraint."""
+    feature_shape = spec.shape
+    if feature_shape and (len(value.shape) < len(feature_shape) or value.shape[-len(feature_shape) :] != feature_shape):
+        return False
+    return bool(spec.is_in(value))

--- a/src/xdrl/types.py
+++ b/src/xdrl/types.py
@@ -15,7 +15,7 @@ import torch
 from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
 from tensordict.utils import NestedKey
-from torchrl.data import TensorSpec
+from torchrl.data import Composite, TensorSpec
 
 #: A TensorDict key, including nested paths such as ``("agents", "action")``.
 TensorDictKey: TypeAlias = NestedKey
@@ -122,9 +122,11 @@ class TensorDictSchema:
                 if entry.presence is KeyPresence.REQUIRED or entry.presence is KeyPresence.PRODUCED:
                     raise SchemaValidationError(f"missing {entry.presence.value} key at {path}")
                 continue
-            if not isinstance(value, torch.Tensor):
-                raise SchemaValidationError(f"key at {path} must contain a torch.Tensor, got {type(value).__name__}")
-            if entry.spec is not None and not _matches_spec(entry.spec, value):
+            if not isinstance(value, (torch.Tensor, TensorDictBase)):
+                raise SchemaValidationError(
+                    f"key at {path} must contain a torch.Tensor or TensorDictBase, got {type(value).__name__}"
+                )
+            if entry.spec is not None and not _matches_spec(entry.spec, value, tensordict.batch_size):
                 raise SchemaValidationError(
                     f"spec mismatch at {path}: got shape={tuple(value.shape)!r}, expected feature shape="
                     f"{tuple(entry.spec.shape)!r} and spec={entry.spec!r}"
@@ -163,11 +165,12 @@ def _display_key(key: TensorDictKey) -> str:
     return "/".join(key) if isinstance(key, tuple) else key
 
 
-def _matches_spec(spec: TensorSpec, value: torch.Tensor) -> bool:
-    """Check feature shape before applying a TorchRL spec membership constraint."""
-    feature_shape = spec.shape
-    if feature_shape and (
-        len(value.shape) < len(feature_shape) or value.shape[-len(feature_shape) :] != feature_shape
-    ):
+def _matches_spec(spec: TensorSpec, value: torch.Tensor | TensorDictBase, batch_size: torch.Size) -> bool:
+    """Check the TensorDict batch prefix and feature shape before spec membership."""
+    if isinstance(value, TensorDictBase):
+        return isinstance(spec, Composite) and bool(spec.is_in(value))
+
+    batch_dims = len(batch_size)
+    if value.shape[:batch_dims] != batch_size or value.shape[batch_dims:] != spec.shape:
         return False
     return bool(spec.is_in(value))

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 from tensordict import TensorDict
-from torchrl.data import UnboundedContinuous
+from torchrl.data import Composite, UnboundedContinuous
 
 from xdrl.types import (
     BatchSemantics,
@@ -49,6 +49,25 @@ def test_validation_reports_spec_and_batch_mismatches() -> None:
         schema.validate_outputs(TensorDict({"value": torch.zeros(2, 1)}, batch_size=[2, 1]))
     with pytest.raises(SchemaValidationError, match="spec mismatch at value"):
         schema.validate_outputs(TensorDict({"value": torch.zeros(2, 2)}, batch_size=[2]))
+    with pytest.raises(SchemaValidationError, match="spec mismatch at value"):
+        schema.validate_outputs(TensorDict({"value": torch.zeros(2, 3, 1)}, batch_size=[2]))
+
+
+def test_composite_spec_validates_a_nested_tensordict_value() -> None:
+    schema = TensorDictSchema(
+        keys=(
+            KeySchema(
+                "agents",
+                KeyRole.OBSERVATION,
+                KeyPresence.REQUIRED,
+                Composite({"observation": UnboundedContinuous(shape=(4,))}),
+            ),
+        ),
+        batch=BatchSemantics(("env",)),
+    )
+    batch = TensorDict({"agents": TensorDict({"observation": torch.zeros(2, 4)}, batch_size=[2])}, batch_size=[2])
+
+    schema.validate_inputs(batch)
 
 
 class _ValueModule:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -18,8 +18,9 @@ from xdrl.types import (
 def test_nested_key_and_vectorised_batch_are_validated_separately() -> None:
     schema = TensorDictSchema(
         keys=(
-            KeySchema(("agents", "observation"), KeyRole.OBSERVATION, KeyPresence.REQUIRED,
-                      UnboundedContinuous(shape=(4,))),
+            KeySchema(
+                ("agents", "observation"), KeyRole.OBSERVATION, KeyPresence.REQUIRED, UnboundedContinuous(shape=(4,))
+            ),
         ),
         batch=BatchSemantics(("env", "agent")),
     )

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+from tensordict import TensorDict
+from torchrl.data import UnboundedContinuous
+
+from xdrl.types import (
+    BatchSemantics,
+    KeyPresence,
+    KeyRole,
+    KeySchema,
+    ModelRole,
+    SchemaValidationError,
+    TensorDictSchema,
+    validate_module,
+)
+
+
+def test_nested_key_and_vectorised_batch_are_validated_separately() -> None:
+    schema = TensorDictSchema(
+        keys=(
+            KeySchema(("agents", "observation"), KeyRole.OBSERVATION, KeyPresence.REQUIRED,
+                      UnboundedContinuous(shape=(4,))),
+        ),
+        batch=BatchSemantics(("env", "agent")),
+    )
+    batch = TensorDict(
+        {"agents": TensorDict({"observation": torch.zeros(2, 3, 4)}, batch_size=[2, 3])}, batch_size=[2, 3]
+    )
+
+    schema.validate_inputs(batch)
+
+
+def test_validation_reports_missing_nested_path() -> None:
+    schema = TensorDictSchema(
+        keys=(KeySchema(("agents", "action"), KeyRole.ACTION, KeyPresence.REQUIRED),),
+        batch=BatchSemantics(("env",)),
+    )
+    with pytest.raises(SchemaValidationError, match="agents/action"):
+        schema.validate_inputs(TensorDict({}, batch_size=[2]))
+
+
+def test_validation_reports_spec_and_batch_mismatches() -> None:
+    schema = TensorDictSchema(
+        keys=(KeySchema("value", KeyRole.VALUE, KeyPresence.PRODUCED, UnboundedContinuous(shape=(1,))),),
+        batch=BatchSemantics(("env",)),
+    )
+    with pytest.raises(SchemaValidationError, match="batch dimensions mismatch"):
+        schema.validate_outputs(TensorDict({"value": torch.zeros(2, 1)}, batch_size=[2, 1]))
+    with pytest.raises(SchemaValidationError, match="spec mismatch at value"):
+        schema.validate_outputs(TensorDict({"value": torch.zeros(2, 2)}, batch_size=[2]))
+
+
+class _ValueModule:
+    role = ModelRole.VALUE
+    input_schema = TensorDictSchema(
+        (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))
+    )
+    output_schema = TensorDictSchema(
+        (KeySchema("value", KeyRole.VALUE, KeyPresence.PRODUCED),), BatchSemantics(("env",))
+    )
+
+    def __call__(self, tensordict: TensorDict, *args: object, **kwargs: object) -> TensorDict:
+        return tensordict.set("value", torch.zeros(*tensordict.batch_size, 1))
+
+
+def test_contract_module_validates_composition() -> None:
+    module = _ValueModule()
+    result = validate_module(module, TensorDict({"observation": torch.zeros(2, 4)}, batch_size=[2]))
+    assert result.get("value").shape == (2, 1)


### PR DESCRIPTION
## Summary

Implements the type and validation foundation for #17.

- adds `xdrl.types`, a TensorDict-native contract layer for model roles, nested key schemas, and separate batch semantics
- validates required/produced keys plus feature shape and TorchRL spec membership with actionable nested paths
- documents the upstream TorchRL/TensorDict mapping and validation boundaries
- covers nested keys, vectorised batches, missing paths, spec and batch mismatches, and contract composition

## Design

This reuses `TensorDictBase`, `NestedKey`, `TensorSpec`, and `TensorDictModuleBase`; it does not introduce a parallel TensorDict container or spec hierarchy. Runtime validation is intended for public composition boundaries, while annotations provide the static contract vocabulary.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -q` (22 passed, 60.77% total coverage)
- `cd docs && uv run --group docs make html`
