### PR TITLE
Add typed RL interaction contexts

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -37,3 +37,22 @@ Use runtime validation at public composition boundaries, not in inner training
 loops. TorchRL's probabilistic actors, value operators, loss modules, and
 exploration modules continue to own their native construction and behavior;
 the contract is only an optional annotation and validation boundary.
+
+Interaction contexts
+--------------------
+
+``xdrl.interactions`` records an individual invocation of a TensorDict module
+without changing TorchRL's collector or trainer loops. An
+``InteractionDescriptor`` is the durable, serialisable record: it identifies
+the role, phase, module path, declared I/O schemas, batch semantics,
+exploration/gradient/autocast configuration, and any supplied logical
+step/episode/trajectory identifiers. It contains neither tensors nor modules.
+
+``RuntimeInteractionContext`` is the matching ephemeral wrapper. Its
+construction checks a representative input against the declared input schema;
+``invoke`` checks live inputs and outputs around the actual module call. The
+context restores exploration, gradient/inference, autocast, and a supplied
+hook context even if the invocation raises. Its ordered ``before``, ``after``,
+and ``failure`` records retain only phase, module path, error text, and key
+shapes. An interaction identity must be stable within an execution record;
+event order is increasing within that identity.

--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -1,6 +1,17 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext
+from xdrl.types import ModelRole, TensorDictSchema
+
 try:
     __version__ = version("xdrl")
 except PackageNotFoundError:
     __version__ = "unknown version"
+
+__all__ = [
+    "InteractionDescriptor",
+    "InteractionPhase",
+    "ModelRole",
+    "RuntimeInteractionContext",
+    "TensorDictSchema",
+]

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -49,6 +49,7 @@ class KeySnapshot:
     presence: str
     feature_shape: tuple[int, ...] | None
     spec_type: str | None
+    spec_constraints: Mapping[str, Any] | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +69,7 @@ class SchemaSnapshot:
                     presence=entry.presence.value,
                     feature_shape=tuple(entry.spec.shape) if entry.spec is not None else None,
                     spec_type=type(entry.spec).__name__ if entry.spec is not None else None,
+                    spec_constraints=_spec_constraints(entry.spec) if entry.spec is not None else None,
                 )
                 for entry in schema.keys
             ),
@@ -155,6 +157,10 @@ class RuntimeInteractionContext:
     _stack: ExitStack | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        if SchemaSnapshot.from_schema(self.input_schema) != self.descriptor.input_schema:
+            raise ValueError("input_schema does not match the interaction descriptor snapshot")
+        if SchemaSnapshot.from_schema(self.output_schema) != self.descriptor.output_schema:
+            raise ValueError("output_schema does not match the interaction descriptor snapshot")
         self.input_schema.validate_inputs(self.representative_input)
 
     def __enter__(self) -> RuntimeInteractionContext:
@@ -164,9 +170,8 @@ class RuntimeInteractionContext:
         try:
             if self.descriptor.exploration_mode is not None:
                 stack.enter_context(set_exploration_type(self.descriptor.exploration_mode))
-            if self.descriptor.inference_mode:
-                stack.enter_context(torch.inference_mode())
-            else:
+            stack.enter_context(torch.inference_mode(self.descriptor.inference_mode))
+            if not self.descriptor.inference_mode:
                 stack.enter_context(torch.set_grad_enabled(self.descriptor.gradient_enabled))
             if self.descriptor.autocast_device_type is not None:
                 stack.enter_context(
@@ -197,9 +202,13 @@ class RuntimeInteractionContext:
         try:
             self.input_schema.validate_inputs(tensordict)
             result = self.module(tensordict)
-            self.output_schema.validate_outputs(result)
         except BaseException as error:
             self._record(LifecycleEventType.FAILURE, tensordict, error)
+            raise
+        try:
+            self.output_schema.validate_outputs(result)
+        except BaseException as error:
+            self._record(LifecycleEventType.FAILURE, result, error)
             raise
         self._record(LifecycleEventType.AFTER, result)
         return result
@@ -231,3 +240,29 @@ def _key_shapes(tensordict: TensorDictBase) -> dict[str, tuple[int, ...] | None]
         path = "/".join(_key_path(key))
         result[path] = tuple(value.shape) if isinstance(value, torch.Tensor) else None
     return result
+
+
+def _spec_constraints(spec: Any) -> dict[str, Any]:
+    """Project TensorSpec validation constraints into JSON-compatible values."""
+    constraints: dict[str, Any] = {}
+    for name in ("dtype", "device", "domain", "low", "high", "n", "nvec", "mask"):
+        if hasattr(spec, name):
+            constraints[name] = _json_value(getattr(spec, name))
+    return constraints
+
+
+def _json_value(value: Any) -> Any:
+    """Convert scalar spec metadata and tensors without retaining tensors."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().tolist()
+    if isinstance(value, (torch.dtype, torch.device)):
+        return str(value)
+    if isinstance(value, torch.Size):
+        return tuple(value)
+    if isinstance(value, tuple):
+        return tuple(_json_value(item) for item in value)
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    return value

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -1,0 +1,233 @@
+"""Typed execution contexts for individual TorchRL model invocations.
+
+The persistent descriptor is deliberately tensor-free and serialisable.  The
+runtime context owns the live module, representative batch, and temporary
+execution state needed to invoke that module safely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import ExitStack
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Protocol
+
+import torch
+from tensordict import TensorDictBase
+from tensordict.nn import TensorDictModuleBase
+from torchrl.envs.utils import set_exploration_type
+
+from xdrl.types import ModelRole, TensorDictKey, TensorDictSchema
+
+
+class InteractionPhase(str, Enum):
+    """Where an RL model invocation occurs."""
+
+    COLLECTION = "collection"
+    EVALUATION = "evaluation"
+    REPLAY = "replay"
+    LOSS = "loss"
+    TARGET = "target"
+    OPTIMISATION = "optimisation"
+
+
+class LifecycleEventType(str, Enum):
+    """Lifecycle state recorded without retaining model inputs or outputs."""
+
+    BEFORE = "before"
+    AFTER = "after"
+    FAILURE = "failure"
+
+
+@dataclass(frozen=True, slots=True)
+class KeySnapshot:
+    """Serialisable description of one declared TensorDict key."""
+
+    path: tuple[str, ...]
+    role: str
+    presence: str
+    feature_shape: tuple[int, ...] | None
+    spec_type: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaSnapshot:
+    """Serialisable projection of a :class:`TensorDictSchema`."""
+
+    keys: tuple[KeySnapshot, ...]
+    batch_dimensions: tuple[str, ...]
+
+    @classmethod
+    def from_schema(cls, schema: TensorDictSchema) -> SchemaSnapshot:
+        return cls(
+            keys=tuple(
+                KeySnapshot(
+                    path=_key_path(entry.key),
+                    role=entry.role.value,
+                    presence=entry.presence.value,
+                    feature_shape=tuple(entry.spec.shape) if entry.spec is not None else None,
+                    spec_type=type(entry.spec).__name__ if entry.spec is not None else None,
+                )
+                for entry in schema.keys
+            ),
+            batch_dimensions=schema.batch.dimensions,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionDescriptor:
+    """Persistent, tensor-free identity and semantics of an interaction.
+
+    ``identity`` must be stable within one recorded run.  Events for a given
+    identity are ordered by their monotonically increasing ``order`` field.
+    """
+
+    identity: str
+    role: ModelRole
+    phase: InteractionPhase
+    module_path: str
+    input_schema: SchemaSnapshot
+    output_schema: SchemaSnapshot
+    batch_dimensions: tuple[str, ...] = ()
+    environment: str | None = None
+    time_dimension: str | None = None
+    agent_dimension: str | None = None
+    objective: str | None = None
+    recurrent_state_keys: tuple[tuple[str, ...], ...] = ()
+    mask_keys: tuple[tuple[str, ...], ...] = ()
+    exploration_mode: str | None = None
+    stochastic_outputs: tuple[tuple[str, ...], ...] = ()
+    gradient_enabled: bool = False
+    inference_mode: bool = False
+    autocast_device_type: str | None = None
+    autocast_enabled: bool = False
+    logical_step: int | None = None
+    episode_id: str | int | None = None
+    trajectory_id: str | int | None = None
+    module_aliases: Mapping[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation with no tensors or modules."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleEvent:
+    """A tensor-free record of one attempted module invocation."""
+
+    order: int
+    kind: LifecycleEventType
+    interaction_id: str
+    phase: InteractionPhase
+    module_path: str
+    key_shapes: Mapping[str, tuple[int, ...] | None]
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible event representation."""
+        return asdict(self)
+
+
+class HookContextFactory(Protocol):
+    """Create a context manager that installs temporary TDHook state."""
+
+    def __call__(self) -> Any: ...
+
+
+@dataclass(slots=True)
+class RuntimeInteractionContext:
+    """Ephemeral execution wrapper around one existing TensorDict module.
+
+    Construction validates the supplied representative input.  ``invoke``
+    validates the live input/output around the actual module call and records
+    lifecycle metadata.  The module itself, tensors, and hook state never
+    enter :class:`InteractionDescriptor` or :class:`LifecycleEvent`.
+    """
+
+    descriptor: InteractionDescriptor
+    module: TensorDictModuleBase
+    input_schema: TensorDictSchema
+    output_schema: TensorDictSchema
+    representative_input: TensorDictBase
+    hook_context_factory: HookContextFactory | None = None
+    events: list[LifecycleEvent] = field(default_factory=list, init=False)
+    _stack: ExitStack | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.input_schema.validate_inputs(self.representative_input)
+
+    def __enter__(self) -> RuntimeInteractionContext:
+        if self._stack is not None:
+            raise RuntimeError("interaction context is already active")
+        stack = ExitStack()
+        try:
+            if self.descriptor.exploration_mode is not None:
+                stack.enter_context(set_exploration_type(self.descriptor.exploration_mode))
+            if self.descriptor.inference_mode:
+                stack.enter_context(torch.inference_mode())
+            else:
+                stack.enter_context(torch.set_grad_enabled(self.descriptor.gradient_enabled))
+            if self.descriptor.autocast_device_type is not None:
+                stack.enter_context(
+                    torch.autocast(
+                        device_type=self.descriptor.autocast_device_type,
+                        enabled=self.descriptor.autocast_enabled,
+                    )
+                )
+            if self.hook_context_factory is not None:
+                stack.enter_context(self.hook_context_factory())
+        except BaseException:
+            stack.close()
+            raise
+        self._stack = stack
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool | None:
+        if self._stack is None:
+            return None
+        stack, self._stack = self._stack, None
+        return stack.__exit__(*exc_info)
+
+    def invoke(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Invoke the wrapped module and append before/after/failure events."""
+        if self._stack is None:
+            raise RuntimeError("invoke must be called inside the interaction context")
+        self._record(LifecycleEventType.BEFORE, tensordict)
+        try:
+            self.input_schema.validate_inputs(tensordict)
+            result = self.module(tensordict)
+            self.output_schema.validate_outputs(result)
+        except BaseException as error:
+            self._record(LifecycleEventType.FAILURE, tensordict, error)
+            raise
+        self._record(LifecycleEventType.AFTER, result)
+        return result
+
+    def _record(
+        self, kind: LifecycleEventType, tensordict: TensorDictBase, error: BaseException | None = None
+    ) -> None:
+        self.events.append(
+            LifecycleEvent(
+                order=len(self.events),
+                kind=kind,
+                interaction_id=self.descriptor.identity,
+                phase=self.descriptor.phase,
+                module_path=self.descriptor.module_path,
+                key_shapes=_key_shapes(tensordict),
+                error=f"{type(error).__name__}: {error}" if error is not None else None,
+            )
+        )
+
+
+def _key_path(key: TensorDictKey) -> tuple[str, ...]:
+    return tuple(str(part) for part in key) if isinstance(key, tuple) else (str(key),)
+
+
+def _key_shapes(tensordict: TensorDictBase) -> dict[str, tuple[int, ...] | None]:
+    """Capture only key paths and shapes, never references to tensor values."""
+    result: dict[str, tuple[int, ...] | None] = {}
+    for key, value in tensordict.items(include_nested=True, leaves_only=True):
+        path = "/".join(_key_path(key))
+        result[path] = tuple(value.shape) if isinstance(value, torch.Tensor) else None
+    return result

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -1,0 +1,118 @@
+from contextlib import contextmanager
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from torchrl.envs.utils import exploration_type
+
+from xdrl.interactions import (
+    InteractionDescriptor,
+    InteractionPhase,
+    LifecycleEventType,
+    RuntimeInteractionContext,
+    SchemaSnapshot,
+)
+from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
+
+
+def _schemas() -> tuple[TensorDictSchema, TensorDictSchema]:
+    return (
+        TensorDictSchema(
+            (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))
+        ),
+        TensorDictSchema((KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),), BatchSemantics(("env",))),
+    )
+
+
+def _policy() -> TensorDictModule:
+    return TensorDictModule(torch.nn.Linear(2, 1, bias=False), in_keys=["observation"], out_keys=["action"])
+
+
+def _descriptor(
+    phase: InteractionPhase, input_schema: TensorDictSchema, output_schema: TensorDictSchema
+) -> InteractionDescriptor:
+    return InteractionDescriptor(
+        identity=f"policy:{phase.value}:7",
+        role=ModelRole.ACTOR,
+        phase=phase,
+        module_path="policy.module",
+        input_schema=SchemaSnapshot.from_schema(input_schema),
+        output_schema=SchemaSnapshot.from_schema(output_schema),
+        batch_dimensions=("env",),
+        exploration_mode="random" if phase is InteractionPhase.COLLECTION else "deterministic",
+        gradient_enabled=False,
+        logical_step=7,
+    )
+
+
+def test_collection_and_evaluation_are_distinct_contexts_for_one_policy() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(3, 2)}, batch_size=[3])
+    collection = RuntimeInteractionContext(
+        _descriptor(InteractionPhase.COLLECTION, inputs, outputs), _policy(), inputs, outputs, batch
+    )
+    evaluation = RuntimeInteractionContext(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs), _policy(), inputs, outputs, batch
+    )
+
+    with collection:
+        collection.invoke(batch.clone())
+    with evaluation:
+        evaluation.invoke(batch.clone())
+
+    assert collection.descriptor.identity != evaluation.descriptor.identity
+    assert collection.descriptor.exploration_mode != evaluation.descriptor.exploration_mode
+    assert [event.kind for event in collection.events] == [LifecycleEventType.BEFORE, LifecycleEventType.AFTER]
+    assert [event.order for event in evaluation.events] == [0, 1]
+
+
+def test_context_restores_execution_and_hook_state_after_exception() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
+    entered: list[str] = []
+
+    @contextmanager
+    def hook_state():
+        entered.append("entered")
+        try:
+            yield
+        finally:
+            entered.append("exited")
+
+    descriptor = _descriptor(InteractionPhase.COLLECTION, inputs, outputs)
+    original_exploration = exploration_type()
+    original_grad = torch.is_grad_enabled()
+    context = RuntimeInteractionContext(descriptor, _policy(), inputs, outputs, batch, hook_state)
+    with pytest.raises(RuntimeError, match="boom"):
+        with context:
+            assert exploration_type().value == "random"
+            assert not torch.is_grad_enabled()
+            raise RuntimeError("boom")
+    assert exploration_type() == original_exploration
+    assert torch.is_grad_enabled() == original_grad
+    assert entered == ["entered", "exited"]
+
+
+class _FailingPolicy:
+    def __call__(self, tensordict: TensorDict) -> TensorDict:
+        raise RuntimeError("policy failure")
+
+
+def test_failure_event_retains_only_diagnostics() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(2, 2)}, batch_size=[2])
+    context = RuntimeInteractionContext(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs), _FailingPolicy(), inputs, outputs, batch
+    )
+
+    with context, pytest.raises(RuntimeError, match="policy failure"):
+        context.invoke(batch)
+
+    failure = context.events[-1]
+    assert failure.kind is LifecycleEventType.FAILURE
+    assert failure.phase is InteractionPhase.EVALUATION
+    assert failure.module_path == "policy.module"
+    assert failure.key_shapes == {"observation": (2, 2)}
+    assert "policy failure" in failure.error
+    assert "tensor" not in repr(failure).lower()

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -1,10 +1,13 @@
 from contextlib import contextmanager
+from dataclasses import replace
+import json
 
 import pytest
 import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 from torchrl.envs.utils import exploration_type
+from torchrl.data import Bounded
 
 from xdrl.interactions import (
     InteractionDescriptor,
@@ -94,9 +97,67 @@ def test_context_restores_execution_and_hook_state_after_exception() -> None:
     assert entered == ["entered", "exited"]
 
 
+def test_context_enables_gradients_inside_outer_inference_mode() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
+    descriptor = _descriptor(InteractionPhase.OPTIMISATION, inputs, outputs)
+    descriptor = replace(descriptor, gradient_enabled=True, inference_mode=False)
+    context = RuntimeInteractionContext(descriptor, _policy(), inputs, outputs, batch)
+
+    with torch.inference_mode():
+        with context:
+            assert torch.is_grad_enabled()
+            assert not torch.is_inference_mode_enabled()
+        assert torch.is_inference_mode_enabled()
+
+
+def test_schema_snapshot_preserves_spec_constraints() -> None:
+    lower = TensorDictSchema(
+        (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED, Bounded(low=-1, high=1, shape=(2,))),),
+        BatchSemantics(("env",)),
+    )
+    wider = TensorDictSchema(
+        (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED, Bounded(low=-2, high=2, shape=(2,))),),
+        BatchSemantics(("env",)),
+    )
+
+    lower_key = SchemaSnapshot.from_schema(lower).keys[0]
+    wider_key = SchemaSnapshot.from_schema(wider).keys[0]
+    assert lower_key.spec_type == wider_key.spec_type
+    assert lower_key.feature_shape == wider_key.feature_shape
+    assert lower_key.spec_constraints != wider_key.spec_constraints
+    descriptor = InteractionDescriptor(
+        "policy:output:0",
+        ModelRole.ACTOR,
+        InteractionPhase.EVALUATION,
+        "policy.module",
+        SchemaSnapshot.from_schema(lower),
+        SchemaSnapshot.from_schema(wider),
+    )
+    json.dumps(descriptor.to_dict())
+
+
+def test_context_rejects_schema_that_disagrees_with_descriptor() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
+    different_outputs = TensorDictSchema(
+        (KeySchema("different_action", KeyRole.ACTION, KeyPresence.PRODUCED),), BatchSemantics(("env",))
+    )
+
+    with pytest.raises(ValueError, match="output_schema does not match"):
+        RuntimeInteractionContext(
+            _descriptor(InteractionPhase.EVALUATION, inputs, outputs), _policy(), inputs, different_outputs, batch
+        )
+
+
 class _FailingPolicy:
     def __call__(self, tensordict: TensorDict) -> TensorDict:
         raise RuntimeError("policy failure")
+
+
+class _InvalidOutputPolicy:
+    def __call__(self, tensordict: TensorDict) -> TensorDict:
+        return TensorDict({"unexpected": torch.zeros(*tensordict.batch_size, 3)}, batch_size=tensordict.batch_size)
 
 
 def test_failure_event_retains_only_diagnostics() -> None:
@@ -116,3 +177,17 @@ def test_failure_event_retains_only_diagnostics() -> None:
     assert failure.key_shapes == {"observation": (2, 2)}
     assert "policy failure" in failure.error
     assert "tensor" not in repr(failure).lower()
+
+
+def test_output_validation_failure_reports_output_shapes() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(2, 2)}, batch_size=[2])
+    context = RuntimeInteractionContext(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs), _InvalidOutputPolicy(), inputs, outputs, batch
+    )
+
+    with context, pytest.raises(Exception, match="missing produced key"):
+        context.invoke(batch)
+
+    assert context.events[-1].kind is LifecycleEventType.FAILURE
+    assert context.events[-1].key_shapes == {"unexpected": (2, 3)}


### PR DESCRIPTION
## Summary

Implements the typed execution-context layer for #16.

- Adds a serialisable, tensor-free interaction descriptor plus ordered lifecycle events.
- Adds an ephemeral context manager that validates representative and live TensorDict batches around an existing module invocation, restoring exploration, gradient/inference, autocast, and supplied hook state on exceptions.
- Documents identity and ordering rules, and covers collection versus deterministic evaluation plus failure diagnostics.

This deliberately does not add a trainer loop, multiprocessing propagation, recurrent-policy inference, or multi-agent reduction semantics.

Closes #16.

## Validation

- `uv run pytest -q tests` (26 passed)
- `uv run pre-commit run --files src/xdrl/interactions.py src/xdrl/__init__.py tests/unit/test_interactions.py docs/source/architecture.rst`
- `uv run --group docs sphinx-build -W --keep-going -b html docs/source build/docs`
- `git diff --check`