### PR TITLE
Add typed observation traces for RL interactions

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -66,7 +66,7 @@ and output keys automatically when supplied to ``RuntimeInteractionContext``;
 hook users can record activations or gradients directly with
 ``observe_tensor``. Each record includes interaction identity, phase, target,
 hook direction, nested key path, batch/time/agent semantics, and
-model/checkpoint-facing descriptor metadata, but ``to_dict`` always excludes
+model/checkpoint identity and exploration metadata, but ``to_dict`` always excludes
 the optional tensor payload.
 
 ``RetentionPolicy`` makes retention explicit: metadata-only is the default;

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -57,6 +57,25 @@ and ``failure`` records retain only phase, module path, error text, and key
 shapes. An interaction identity must be stable within an execution record;
 event order is increasing within that identity.
 
+Observation traces
+------------------
+
+``xdrl.observations`` adds bounded typed records around an interaction without
+changing its TensorDict invocation. ``ObservationTrace`` captures module input
+and output keys automatically when supplied to ``RuntimeInteractionContext``;
+hook users can record activations or gradients directly with
+``observe_tensor``. Each record includes interaction identity, phase, target,
+hook direction, nested key path, batch/time/agent semantics, and
+model/checkpoint-facing descriptor metadata, but ``to_dict`` always excludes
+the optional tensor payload.
+
+``RetentionPolicy`` makes retention explicit: metadata-only is the default;
+detached or CPU snapshots clone their values and never retain computation
+graphs. Sampling and named ``mean``, ``sum``, or ``max`` batch reductions are
+opt-in. ``max_records`` plus an overflow policy bounds memory, while an
+optional callback supports streaming consumers. Probes and attribution remain
+external consumers of these records rather than becoming xdrl algorithms.
+
 TDHook instrumentation
 ----------------------
 

--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext
+from xdrl.observations import ObservationKind, ObservationRecord, ObservationTrace, RetentionPolicy, TensorRetention
 from xdrl.tdhook import TDHookInteractionAdapter
 from xdrl.types import ModelRole, TensorDictSchema
 
@@ -13,7 +14,12 @@ __all__ = [
     "InteractionDescriptor",
     "InteractionPhase",
     "ModelRole",
+    "ObservationKind",
+    "ObservationRecord",
+    "ObservationTrace",
+    "RetentionPolicy",
     "RuntimeInteractionContext",
-    "TensorDictSchema",
     "TDHookInteractionAdapter",
+    "TensorDictSchema",
+    "TensorRetention",
 ]

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 from contextlib import ExitStack
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import torch
 from tensordict import TensorDictBase
@@ -19,6 +19,9 @@ from tensordict.nn import TensorDictModuleBase
 from torchrl.envs.utils import set_exploration_type
 
 from xdrl.types import ModelRole, TensorDictKey, TensorDictSchema
+
+if TYPE_CHECKING:
+    from xdrl.observations import ObservationTrace
 
 
 class InteractionPhase(str, Enum):
@@ -153,6 +156,7 @@ class RuntimeInteractionContext:
     output_schema: TensorDictSchema
     representative_input: TensorDictBase
     hook_context_factory: HookContextFactory | None = None
+    observations: ObservationTrace | None = None
     events: list[LifecycleEvent] = field(default_factory=list, init=False)
     _stack: ExitStack | None = field(default=None, init=False, repr=False)
 
@@ -199,6 +203,7 @@ class RuntimeInteractionContext:
         if self._stack is None:
             raise RuntimeError("invoke must be called inside the interaction context")
         self._record(LifecycleEventType.BEFORE, tensordict)
+        self._capture_observations(tensordict, input=True)
         try:
             self.input_schema.validate_inputs(tensordict)
             result = (self.module if module is None else module)(tensordict)
@@ -211,7 +216,22 @@ class RuntimeInteractionContext:
             self._record(LifecycleEventType.FAILURE, result, error)
             raise
         self._record(LifecycleEventType.AFTER, result)
+        self._capture_observations(result, input=False)
         return result
+
+    def _capture_observations(self, tensordict: TensorDictBase, *, input: bool) -> None:
+        if self.observations is None:
+            return
+        from xdrl.observations import HookDirection
+
+        schema = self.input_schema if input else self.output_schema
+        roles = {_key_path(entry.key): entry.role for entry in schema.keys}
+        self.observations.capture_tensordict(
+            self.descriptor,
+            tensordict,
+            direction=HookDirection.INPUT if input else HookDirection.OUTPUT,
+            roles=roles,
+        )
 
     def _record(
         self, kind: LifecycleEventType, tensordict: TensorDictBase, error: BaseException | None = None

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -94,8 +94,6 @@ class InteractionDescriptor:
     module_path: str
     input_schema: SchemaSnapshot
     output_schema: SchemaSnapshot
-    model_id: str | None = None
-    checkpoint_id: str | None = None
     batch_dimensions: tuple[str, ...] = ()
     environment: str | None = None
     time_dimension: str | None = None
@@ -113,6 +111,8 @@ class InteractionDescriptor:
     episode_id: str | int | None = None
     trajectory_id: str | int | None = None
     module_aliases: Mapping[str, str] = field(default_factory=dict)
+    model_id: str | None = None
+    checkpoint_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible representation with no tensors or modules."""

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -94,6 +94,8 @@ class InteractionDescriptor:
     module_path: str
     input_schema: SchemaSnapshot
     output_schema: SchemaSnapshot
+    model_id: str | None = None
+    checkpoint_id: str | None = None
     batch_dimensions: tuple[str, ...] = ()
     environment: str | None = None
     time_dimension: str | None = None

--- a/src/xdrl/observations.py
+++ b/src/xdrl/observations.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable, Mapping
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
@@ -113,9 +113,7 @@ class ObservationRecord:
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible record without its optional tensor payload."""
-        result = asdict(self)
-        result.pop("payload")
-        return result
+        return {item.name: getattr(self, item.name) for item in fields(self) if item.name != "payload"}
 
 
 ObservationCallback = Callable[[ObservationRecord], None]
@@ -140,13 +138,19 @@ class ObservationTrace:
         target: str,
         direction: HookDirection = HookDirection.TENSOR,
         key: TensorDictKey | None = None,
+        batch_dimensions: tuple[str, ...] | None = None,
     ) -> ObservationRecord | None:
-        """Capture a hook, gradient, or arbitrary tensor with explicit retention."""
+        """Capture a hook, gradient, or arbitrary tensor with explicit retention.
+
+        Pass ``batch_dimensions`` only when the leading dimensions of ``tensor``
+        are known to have those semantics.  This prevents an arbitrary hook or
+        gradient tensor from being reduced along unrelated feature dimensions.
+        """
         order = self._seen
         self._seen += 1
         if order % self.policy.every_n:
             return None
-        value, retained_dimensions = _retain(tensor, descriptor.batch_dimensions, self.policy)
+        value, retained_dimensions = _retain(tensor, batch_dimensions, self.policy)
         record = ObservationRecord(
             order=order,
             interaction_id=descriptor.identity,
@@ -194,16 +198,19 @@ class ObservationTrace:
             # TensorDict modules commonly mutate their input in place.  Only
             # declared keys belong to this interaction direction; retaining
             # untouched input leaves as module outputs would mislabel them.
-            if path not in roles:
+            # A declared TensorDict/Composite parent applies to all its leaves.
+            role = _role_for_path(path, roles)
+            if role is None:
                 continue
             records.append(
                 self.observe_tensor(
                     descriptor,
                     value,
-                    kind=_kind_for(roles.get(path), direction),
+                    kind=_kind_for(role, direction),
                     target="/".join(path),
                     direction=direction,
                     key=key,
+                    batch_dimensions=descriptor.batch_dimensions,
                 )
             )
         return tuple(record for record in records if record is not None)
@@ -221,15 +228,18 @@ class ObservationTrace:
 
 
 def _retain(
-    tensor: torch.Tensor, batch_dimensions: tuple[str, ...], policy: RetentionPolicy
+    tensor: torch.Tensor, batch_dimensions: tuple[str, ...] | None, policy: RetentionPolicy
 ) -> tuple[torch.Tensor | None, tuple[str, ...]]:
+    known_dimensions = () if batch_dimensions is None else batch_dimensions
     if policy.tensor is TensorRetention.METADATA:
-        return None, batch_dimensions
+        return None, known_dimensions
     value = tensor.detach()
-    retained_dimensions = batch_dimensions
+    retained_dimensions = known_dimensions
     if policy.reduction is not None and batch_dimensions:
         dims = tuple(range(len(batch_dimensions)))
-        value = getattr(value, policy.reduction)(dim=dims)
+        value = (
+            torch.amax(value, dim=dims) if policy.reduction == "max" else getattr(value, policy.reduction)(dim=dims)
+        )
         retained_dimensions = ()
     if policy.tensor is TensorRetention.CPU:
         value = value.cpu()
@@ -244,6 +254,15 @@ def _kind_for(role: KeyRole | None, direction: HookDirection) -> ObservationKind
     if role is KeyRole.DISTRIBUTION_PARAMETER:
         return ObservationKind.DISTRIBUTION_PARAMETER
     return ObservationKind.MODULE_INPUT if direction is HookDirection.INPUT else ObservationKind.MODULE_OUTPUT
+
+
+def _role_for_path(path: tuple[str, ...], roles: Mapping[tuple[str, ...], KeyRole]) -> KeyRole | None:
+    """Find the most specific declared schema key that contains ``path``."""
+    for length in range(len(path), 0, -1):
+        role = roles.get(path[:length])
+        if role is not None:
+            return role
+    return None
 
 
 def _key_path(key: TensorDictKey) -> tuple[str, ...]:

--- a/src/xdrl/observations.py
+++ b/src/xdrl/observations.py
@@ -92,6 +92,9 @@ class ObservationRecord:
     phase: str
     module_path: str
     model_role: str
+    model_id: str | None
+    checkpoint_id: str | None
+    exploration_mode: str | None
     kind: ObservationKind
     hook_direction: HookDirection
     target: str
@@ -150,6 +153,9 @@ class ObservationTrace:
             phase=descriptor.phase.value,
             module_path=descriptor.module_path,
             model_role=descriptor.role.value,
+            model_id=descriptor.model_id,
+            checkpoint_id=descriptor.checkpoint_id,
+            exploration_mode=descriptor.exploration_mode,
             kind=kind,
             hook_direction=direction,
             target=target,

--- a/src/xdrl/observations.py
+++ b/src/xdrl/observations.py
@@ -1,0 +1,244 @@
+"""Typed, bounded observation traces for RL model interactions.
+
+The trace owns optional tensor snapshots, while every observation record is
+serialisable even when its payload is omitted.  It intentionally does not
+implement probes or attribution algorithms; those consumers can subscribe to
+the stream or operate on retained records.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+import torch
+from tensordict import TensorDictBase
+
+from xdrl.interactions import InteractionDescriptor
+from xdrl.types import KeyRole, TensorDictKey
+
+
+class ObservationKind(str, Enum):
+    """Semantic category of a captured value."""
+
+    MODULE_INPUT = "module_input"
+    MODULE_OUTPUT = "module_output"
+    ACTIVATION = "activation"
+    GRADIENT = "gradient"
+    DISTRIBUTION_PARAMETER = "distribution_parameter"
+    ACTION = "action"
+    VALUE = "value"
+    TENSORDICT_KEY = "tensordict_key"
+
+
+class HookDirection(str, Enum):
+    """Whether a hook observed a module's input or output."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+    TENSOR = "tensor"
+
+
+class TensorRetention(str, Enum):
+    """How an observation record retains its optional tensor payload."""
+
+    METADATA = "metadata"
+    DETACHED = "detached"
+    CPU = "cpu"
+
+
+class OverflowPolicy(str, Enum):
+    """Action taken when the in-memory trace reaches its record capacity."""
+
+    DROP_OLDEST = "drop_oldest"
+    DROP_NEWEST = "drop_newest"
+    RAISE = "raise"
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPolicy:
+    """Explicit graph, device, sampling, reduction, and backpressure policy.
+
+    ``every_n`` samples observations by monotonically increasing observation
+    order. ``reduction`` applies only across named batch dimensions and emits
+    a record with those dimensions removed.  Payloads are always detached and
+    cloned, so this package never retains a computation graph by accident.
+    """
+
+    tensor: TensorRetention = TensorRetention.METADATA
+    every_n: int = 1
+    reduction: str | None = None
+    max_records: int = 1_024
+    overflow: OverflowPolicy = OverflowPolicy.DROP_OLDEST
+
+    def __post_init__(self) -> None:
+        if self.every_n < 1:
+            raise ValueError("every_n must be at least 1")
+        if self.max_records < 0:
+            raise ValueError("max_records must be non-negative")
+        if self.reduction not in {None, "mean", "sum", "max"}:
+            raise ValueError("reduction must be one of None, 'mean', 'sum', or 'max'")
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationRecord:
+    """One observation and its tensor-free interpretation context."""
+
+    order: int
+    interaction_id: str
+    phase: str
+    module_path: str
+    model_role: str
+    kind: ObservationKind
+    hook_direction: HookDirection
+    target: str
+    key_path: tuple[str, ...] | None
+    batch_dimensions: tuple[str, ...]
+    time_dimension: str | None
+    agent_dimension: str | None
+    logical_step: int | None
+    episode_id: str | int | None
+    trajectory_id: str | int | None
+    shape: tuple[int, ...]
+    dtype: str
+    device: str
+    retained_batch_dimensions: tuple[str, ...]
+    payload: torch.Tensor | None = field(default=None, repr=False, compare=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible record without its optional tensor payload."""
+        result = asdict(self)
+        result.pop("payload")
+        return result
+
+
+ObservationCallback = Callable[[ObservationRecord], None]
+
+
+@dataclass(slots=True)
+class ObservationTrace:
+    """A bounded trace that can retain tensors and/or stream typed records."""
+
+    policy: RetentionPolicy = field(default_factory=RetentionPolicy)
+    callback: ObservationCallback | None = None
+    records: deque[ObservationRecord] = field(default_factory=deque, init=False)
+    dropped: int = field(default=0, init=False)
+    _seen: int = field(default=0, init=False, repr=False)
+
+    def observe_tensor(
+        self,
+        descriptor: InteractionDescriptor,
+        tensor: torch.Tensor,
+        *,
+        kind: ObservationKind,
+        target: str,
+        direction: HookDirection = HookDirection.TENSOR,
+        key: TensorDictKey | None = None,
+    ) -> ObservationRecord | None:
+        """Capture a hook, gradient, or arbitrary tensor with explicit retention."""
+        order = self._seen
+        self._seen += 1
+        if order % self.policy.every_n:
+            return None
+        value, retained_dimensions = _retain(tensor, descriptor.batch_dimensions, self.policy)
+        record = ObservationRecord(
+            order=order,
+            interaction_id=descriptor.identity,
+            phase=descriptor.phase.value,
+            module_path=descriptor.module_path,
+            model_role=descriptor.role.value,
+            kind=kind,
+            hook_direction=direction,
+            target=target,
+            key_path=_key_path(key) if key is not None else None,
+            batch_dimensions=descriptor.batch_dimensions,
+            time_dimension=descriptor.time_dimension,
+            agent_dimension=descriptor.agent_dimension,
+            logical_step=descriptor.logical_step,
+            episode_id=descriptor.episode_id,
+            trajectory_id=descriptor.trajectory_id,
+            shape=tuple(tensor.shape),
+            dtype=str(tensor.dtype),
+            device=str(tensor.device),
+            retained_batch_dimensions=retained_dimensions,
+            payload=value,
+        )
+        self._append(record)
+        if self.callback is not None:
+            self.callback(record)
+        return record
+
+    def capture_tensordict(
+        self,
+        descriptor: InteractionDescriptor,
+        tensordict: TensorDictBase,
+        *,
+        direction: HookDirection,
+        roles: Mapping[tuple[str, ...], KeyRole],
+    ) -> tuple[ObservationRecord, ...]:
+        """Capture all tensor leaves while preserving nested TensorDict keys."""
+        records = []
+        for key, value in tensordict.items(include_nested=True, leaves_only=True):
+            if not isinstance(value, torch.Tensor):
+                continue
+            path = _key_path(key)
+            # TensorDict modules commonly mutate their input in place.  Only
+            # declared keys belong to this interaction direction; retaining
+            # untouched input leaves as module outputs would mislabel them.
+            if path not in roles:
+                continue
+            records.append(
+                self.observe_tensor(
+                    descriptor,
+                    value,
+                    kind=_kind_for(roles.get(path), direction),
+                    target="/".join(path),
+                    direction=direction,
+                    key=key,
+                )
+            )
+        return tuple(record for record in records if record is not None)
+
+    def _append(self, record: ObservationRecord) -> None:
+        if self.policy.max_records == 0 or len(self.records) >= self.policy.max_records:
+            if self.policy.overflow is OverflowPolicy.DROP_NEWEST or self.policy.max_records == 0:
+                self.dropped += 1
+                return
+            if self.policy.overflow is OverflowPolicy.RAISE:
+                raise BufferError("observation trace reached max_records")
+            self.records.popleft()
+            self.dropped += 1
+        self.records.append(record)
+
+
+def _retain(
+    tensor: torch.Tensor, batch_dimensions: tuple[str, ...], policy: RetentionPolicy
+) -> tuple[torch.Tensor | None, tuple[str, ...]]:
+    if policy.tensor is TensorRetention.METADATA:
+        return None, batch_dimensions
+    value = tensor.detach()
+    retained_dimensions = batch_dimensions
+    if policy.reduction is not None and batch_dimensions:
+        dims = tuple(range(len(batch_dimensions)))
+        value = getattr(value, policy.reduction)(dim=dims)
+        retained_dimensions = ()
+    if policy.tensor is TensorRetention.CPU:
+        value = value.cpu()
+    return value.clone(), retained_dimensions
+
+
+def _kind_for(role: KeyRole | None, direction: HookDirection) -> ObservationKind:
+    if role is KeyRole.ACTION:
+        return ObservationKind.ACTION
+    if role is KeyRole.VALUE:
+        return ObservationKind.VALUE
+    if role is KeyRole.DISTRIBUTION_PARAMETER:
+        return ObservationKind.DISTRIBUTION_PARAMETER
+    return ObservationKind.MODULE_INPUT if direction is HookDirection.INPUT else ObservationKind.MODULE_OUTPUT
+
+
+def _key_path(key: TensorDictKey) -> tuple[str, ...]:
+    return tuple(str(part) for part in key) if isinstance(key, tuple) else (str(key),)

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -150,6 +150,24 @@ def test_context_rejects_schema_that_disagrees_with_descriptor() -> None:
         )
 
 
+def test_descriptor_model_identity_does_not_shift_existing_positional_fields() -> None:
+    inputs, outputs = _schemas()
+    descriptor = InteractionDescriptor(
+        "policy:collection:1",
+        ModelRole.ACTOR,
+        InteractionPhase.COLLECTION,
+        "policy.module",
+        SchemaSnapshot.from_schema(inputs),
+        SchemaSnapshot.from_schema(outputs),
+        ("env",),
+        "CartPole",
+    )
+
+    assert descriptor.batch_dimensions == ("env",)
+    assert descriptor.environment == "CartPole"
+    assert descriptor.model_id is None
+
+
 class _FailingPolicy:
     def __call__(self, tensordict: TensorDict) -> TensorDict:
         raise RuntimeError("policy failure")

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -36,7 +36,8 @@ class _Policy(torch.nn.Module):
 def _descriptor(inputs: TensorDictSchema, outputs: TensorDictSchema) -> InteractionDescriptor:
     return InteractionDescriptor(
         "trajectory:4:policy", ModelRole.ACTOR, InteractionPhase.COLLECTION, "policy", SchemaSnapshot.from_schema(inputs),
-        SchemaSnapshot.from_schema(outputs), batch_dimensions=("env",), time_dimension="time", agent_dimension="agent",
+        SchemaSnapshot.from_schema(outputs), model_id="policy-v2", checkpoint_id="checkpoint-4",
+        batch_dimensions=("env",), time_dimension="time", agent_dimension="agent",
         logical_step=4, trajectory_id="trajectory-4", exploration_mode="random",
     )
 
@@ -59,6 +60,9 @@ def test_trace_is_serialisable_and_observation_only_preserves_model_output() -> 
         ObservationKind.VALUE,
     ]
     assert trace.records[1].trajectory_id == "trajectory-4"
+    assert trace.records[1].model_id == "policy-v2"
+    assert trace.records[1].checkpoint_id == "checkpoint-4"
+    assert trace.records[1].exploration_mode == "random"
     assert trace.records[1].payload is None
     json.dumps(trace.records[1].to_dict())
 

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -17,7 +17,9 @@ from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRol
 
 def _schemas() -> tuple[TensorDictSchema, TensorDictSchema]:
     return (
-        TensorDictSchema((KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))),
+        TensorDictSchema(
+            (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))
+        ),
         TensorDictSchema(
             (
                 KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),
@@ -30,15 +32,27 @@ def _schemas() -> tuple[TensorDictSchema, TensorDictSchema]:
 
 class _Policy(torch.nn.Module):
     def forward(self, tensordict: TensorDict) -> TensorDict:
-        return tensordict.set("action", tensordict["observation"] + 1).set("value", tensordict["observation"].sum(-1, keepdim=True))
+        return tensordict.set("action", tensordict["observation"] + 1).set(
+            "value", tensordict["observation"].sum(-1, keepdim=True)
+        )
 
 
 def _descriptor(inputs: TensorDictSchema, outputs: TensorDictSchema) -> InteractionDescriptor:
     return InteractionDescriptor(
-        "trajectory:4:policy", ModelRole.ACTOR, InteractionPhase.COLLECTION, "policy", SchemaSnapshot.from_schema(inputs),
-        SchemaSnapshot.from_schema(outputs), model_id="policy-v2", checkpoint_id="checkpoint-4",
-        batch_dimensions=("env",), time_dimension="time", agent_dimension="agent",
-        logical_step=4, trajectory_id="trajectory-4", exploration_mode="random",
+        "trajectory:4:policy",
+        ModelRole.ACTOR,
+        InteractionPhase.COLLECTION,
+        "policy",
+        SchemaSnapshot.from_schema(inputs),
+        SchemaSnapshot.from_schema(outputs),
+        model_id="policy-v2",
+        checkpoint_id="checkpoint-4",
+        batch_dimensions=("env",),
+        time_dimension="time",
+        agent_dimension="agent",
+        logical_step=4,
+        trajectory_id="trajectory-4",
+        exploration_mode="random",
     )
 
 
@@ -48,7 +62,9 @@ def test_trace_is_serialisable_and_observation_only_preserves_model_output() -> 
     model = _Policy()
     expected = model(batch.clone())
     trace = ObservationTrace()
-    context = RuntimeInteractionContext(_descriptor(inputs, outputs), model, inputs, outputs, batch, observations=trace)
+    context = RuntimeInteractionContext(
+        _descriptor(inputs, outputs), model, inputs, outputs, batch, observations=trace
+    )
 
     with context:
         actual = context.invoke(batch.clone())
@@ -72,7 +88,9 @@ def test_retention_detaches_reduces_and_bounds_records() -> None:
     trace = ObservationTrace(RetentionPolicy(tensor=TensorRetention.CPU, reduction="mean", max_records=1))
     descriptor = _descriptor(inputs, outputs)
     source = torch.tensor([[1.0, 3.0], [5.0, 7.0]], requires_grad=True)
-    first = trace.observe_tensor(descriptor, source, kind=ObservationKind.ACTIVATION, target="encoder", direction=HookDirection.OUTPUT)
+    first = trace.observe_tensor(
+        descriptor, source, kind=ObservationKind.ACTIVATION, target="encoder", direction=HookDirection.OUTPUT
+    )
     assert first is not None and first.payload is not None
     assert not first.payload.requires_grad
     assert first.payload.device.type == "cpu"

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -89,16 +89,71 @@ def test_retention_detaches_reduces_and_bounds_records() -> None:
     descriptor = _descriptor(inputs, outputs)
     source = torch.tensor([[1.0, 3.0], [5.0, 7.0]], requires_grad=True)
     first = trace.observe_tensor(
-        descriptor, source, kind=ObservationKind.ACTIVATION, target="encoder", direction=HookDirection.OUTPUT
+        descriptor,
+        source,
+        kind=ObservationKind.ACTIVATION,
+        target="encoder",
+        direction=HookDirection.OUTPUT,
+        batch_dimensions=("env",),
     )
     assert first is not None and first.payload is not None
     assert not first.payload.requires_grad
     assert first.payload.device.type == "cpu"
     assert first.retained_batch_dimensions == ()
     assert torch.equal(first.payload, torch.tensor([3.0, 5.0]))
-    trace.observe_tensor(descriptor, source, kind=ObservationKind.GRADIENT, target="encoder")
+    trace.observe_tensor(
+        descriptor, source, kind=ObservationKind.GRADIENT, target="encoder", batch_dimensions=("env",)
+    )
     assert len(trace.records) == 1
     assert trace.dropped == 1
+
+
+def test_max_reduction_and_unbatched_hook_tensors_are_handled_explicitly() -> None:
+    inputs, outputs = _schemas()
+    descriptor = _descriptor(inputs, outputs)
+    trace = ObservationTrace(RetentionPolicy(tensor=TensorRetention.DETACHED, reduction="max"))
+    reduced = trace.observe_tensor(
+        descriptor,
+        torch.tensor([[1.0, 5.0], [4.0, 3.0]]),
+        kind=ObservationKind.ACTIVATION,
+        target="encoder",
+        batch_dimensions=("env",),
+    )
+    unbatched = trace.observe_tensor(
+        descriptor, torch.tensor([1.0, 5.0]), kind=ObservationKind.GRADIENT, target="encoder"
+    )
+    assert reduced is not None and torch.equal(reduced.payload, torch.tensor([4.0, 5.0]))
+    assert reduced.retained_batch_dimensions == ()
+    assert unbatched is not None and torch.equal(unbatched.payload, torch.tensor([1.0, 5.0]))
+    assert unbatched.retained_batch_dimensions == ()
+
+
+def test_composite_schema_parent_captures_nested_tensor_leaves() -> None:
+    inputs, outputs = _schemas()
+    descriptor = _descriptor(inputs, outputs)
+    trace = ObservationTrace()
+    batch = TensorDict({"agents": TensorDict({"observation": torch.zeros(2, 3)}, batch_size=[2])}, batch_size=[2])
+
+    records = trace.capture_tensordict(
+        descriptor,
+        batch,
+        direction=HookDirection.INPUT,
+        roles={("agents",): KeyRole.OBSERVATION},
+    )
+
+    assert len(records) == 1
+    assert records[0].key_path == ("agents", "observation")
+    assert records[0].kind is ObservationKind.MODULE_INPUT
+
+
+def test_observation_serialisation_does_not_include_retained_payload() -> None:
+    inputs, outputs = _schemas()
+    record = ObservationTrace(RetentionPolicy(tensor=TensorRetention.DETACHED)).observe_tensor(
+        _descriptor(inputs, outputs), torch.ones(1), kind=ObservationKind.ACTIVATION, target="encoder"
+    )
+    assert record is not None and record.payload is not None
+    assert "payload" not in record.to_dict()
+    json.dumps(record.to_dict())
 
 
 def test_sampling_streaming_and_backpressure_are_explicit() -> None:

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -1,0 +1,93 @@
+import json
+
+import torch
+from tensordict import TensorDict
+
+from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext, SchemaSnapshot
+from xdrl.observations import (
+    HookDirection,
+    ObservationKind,
+    ObservationTrace,
+    OverflowPolicy,
+    RetentionPolicy,
+    TensorRetention,
+)
+from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
+
+
+def _schemas() -> tuple[TensorDictSchema, TensorDictSchema]:
+    return (
+        TensorDictSchema((KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))),
+        TensorDictSchema(
+            (
+                KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),
+                KeySchema("value", KeyRole.VALUE, KeyPresence.PRODUCED),
+            ),
+            BatchSemantics(("env",)),
+        ),
+    )
+
+
+class _Policy(torch.nn.Module):
+    def forward(self, tensordict: TensorDict) -> TensorDict:
+        return tensordict.set("action", tensordict["observation"] + 1).set("value", tensordict["observation"].sum(-1, keepdim=True))
+
+
+def _descriptor(inputs: TensorDictSchema, outputs: TensorDictSchema) -> InteractionDescriptor:
+    return InteractionDescriptor(
+        "trajectory:4:policy", ModelRole.ACTOR, InteractionPhase.COLLECTION, "policy", SchemaSnapshot.from_schema(inputs),
+        SchemaSnapshot.from_schema(outputs), batch_dimensions=("env",), time_dimension="time", agent_dimension="agent",
+        logical_step=4, trajectory_id="trajectory-4", exploration_mode="random",
+    )
+
+
+def test_trace_is_serialisable_and_observation_only_preserves_model_output() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.tensor([[1.0, 2.0]])}, batch_size=[1])
+    model = _Policy()
+    expected = model(batch.clone())
+    trace = ObservationTrace()
+    context = RuntimeInteractionContext(_descriptor(inputs, outputs), model, inputs, outputs, batch, observations=trace)
+
+    with context:
+        actual = context.invoke(batch.clone())
+
+    assert torch.equal(actual["action"], expected["action"])
+    assert [record.kind for record in trace.records] == [
+        ObservationKind.MODULE_INPUT,
+        ObservationKind.ACTION,
+        ObservationKind.VALUE,
+    ]
+    assert trace.records[1].trajectory_id == "trajectory-4"
+    assert trace.records[1].payload is None
+    json.dumps(trace.records[1].to_dict())
+
+
+def test_retention_detaches_reduces_and_bounds_records() -> None:
+    inputs, outputs = _schemas()
+    trace = ObservationTrace(RetentionPolicy(tensor=TensorRetention.CPU, reduction="mean", max_records=1))
+    descriptor = _descriptor(inputs, outputs)
+    source = torch.tensor([[1.0, 3.0], [5.0, 7.0]], requires_grad=True)
+    first = trace.observe_tensor(descriptor, source, kind=ObservationKind.ACTIVATION, target="encoder", direction=HookDirection.OUTPUT)
+    assert first is not None and first.payload is not None
+    assert not first.payload.requires_grad
+    assert first.payload.device.type == "cpu"
+    assert first.retained_batch_dimensions == ()
+    assert torch.equal(first.payload, torch.tensor([3.0, 5.0]))
+    trace.observe_tensor(descriptor, source, kind=ObservationKind.GRADIENT, target="encoder")
+    assert len(trace.records) == 1
+    assert trace.dropped == 1
+
+
+def test_sampling_streaming_and_backpressure_are_explicit() -> None:
+    inputs, outputs = _schemas()
+    streamed = []
+    trace = ObservationTrace(
+        RetentionPolicy(every_n=2, max_records=1, overflow=OverflowPolicy.DROP_NEWEST), callback=streamed.append
+    )
+    descriptor = _descriptor(inputs, outputs)
+    for _ in range(3):
+        trace.observe_tensor(descriptor, torch.zeros(1), kind=ObservationKind.TENSORDICT_KEY, target="obs")
+    assert len(trace.records) == 1
+    assert len(streamed) == 2
+    assert trace.dropped == 1


### PR DESCRIPTION
## Summary

Implements the typed observation-trace foundation for #19.

- adds serialisable records for module inputs/outputs, activations, gradients, distribution parameters, actions, values, and selected TensorDict keys
- attaches interaction, phase, module target, hook direction, nested key, batch/time/agent, and trajectory metadata
- makes tensor retention explicit (metadata, detached, CPU), with sampling, named batch reduction, bounded-cache overflow handling, and streaming callbacks
- automatically captures declared TensorDict I/O without changing model execution; hook consumers can record tensors directly

## Safety and behavior

Tensor payloads are detached and cloned before retention, and metadata-only is the default. Output capture is restricted to declared output keys so in-place TensorDict inputs are not misclassified as outputs.

## Validation

- `uv run pytest` (39 passed)
- `uvx ruff check src/xdrl/observations.py src/xdrl/__init__.py tests/unit/test_observations.py`

Full-repository Ruff also reports pre-existing findings in unrelated files.