### PR TITLE
Add spec-checked TDHook interventions

### DIFF
--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -1,6 +1,18 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext
+from xdrl.interventions import (
+    Intervention,
+    InterventionController,
+    InterventionRecord,
+    InterventionScope,
+    InterventionTarget,
+    InterventionTiming,
+    InterventionValidationError,
+    PairedInterventionResult,
+    TDHookInterventionFactory,
+    run_paired,
+)
 from xdrl.observations import ObservationKind, ObservationRecord, ObservationTrace, RetentionPolicy, TensorRetention
 from xdrl.tdhook import TDHookInteractionAdapter
 from xdrl.types import ModelRole, TensorDictSchema
@@ -12,6 +24,13 @@ except PackageNotFoundError:
 
 __all__ = [
     "InteractionDescriptor",
+    "Intervention",
+    "InterventionController",
+    "InterventionRecord",
+    "InterventionScope",
+    "InterventionTarget",
+    "InterventionTiming",
+    "InterventionValidationError",
     "InteractionPhase",
     "ModelRole",
     "ObservationKind",
@@ -19,7 +38,10 @@ __all__ = [
     "ObservationTrace",
     "RetentionPolicy",
     "RuntimeInteractionContext",
+    "PairedInterventionResult",
     "TDHookInteractionAdapter",
+    "TDHookInterventionFactory",
     "TensorDictSchema",
     "TensorRetention",
+    "run_paired",
 ]

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -18,9 +18,11 @@ from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
 from torchrl.envs.utils import set_exploration_type
 
+from xdrl.interventions import InterventionTiming
 from xdrl.types import ModelRole, TensorDictKey, TensorDictSchema
 
 if TYPE_CHECKING:
+    from xdrl.interventions import InterventionController
     from xdrl.observations import ObservationTrace
 
 
@@ -159,6 +161,7 @@ class RuntimeInteractionContext:
     representative_input: TensorDictBase
     hook_context_factory: HookContextFactory | None = None
     observations: ObservationTrace | None = None
+    interventions: InterventionController | None = None
     events: list[LifecycleEvent] = field(default_factory=list, init=False)
     _stack: ExitStack | None = field(default=None, init=False, repr=False)
 
@@ -168,6 +171,8 @@ class RuntimeInteractionContext:
         if SchemaSnapshot.from_schema(self.output_schema) != self.descriptor.output_schema:
             raise ValueError("output_schema does not match the interaction descriptor snapshot")
         self.input_schema.validate_inputs(self.representative_input)
+        if self.interventions is not None:
+            self.interventions.validate(self)
 
     def __enter__(self) -> RuntimeInteractionContext:
         if self._stack is not None:
@@ -208,12 +213,16 @@ class RuntimeInteractionContext:
         self._capture_observations(tensordict, input=True)
         try:
             self.input_schema.validate_inputs(tensordict)
+            if self.interventions is not None:
+                tensordict = self.interventions.apply(self, tensordict, InterventionTiming.INPUT)
             result = (self.module if module is None else module)(tensordict)
         except BaseException as error:
             self._record(LifecycleEventType.FAILURE, tensordict, error)
             raise
         try:
             self.output_schema.validate_outputs(result)
+            if self.interventions is not None:
+                result = self.interventions.apply(self, result, InterventionTiming.OUTPUT)
         except BaseException as error:
             self._record(LifecycleEventType.FAILURE, result, error)
             raise

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -210,11 +210,11 @@ class RuntimeInteractionContext:
         if self._stack is None:
             raise RuntimeError("invoke must be called inside the interaction context")
         self._record(LifecycleEventType.BEFORE, tensordict)
-        self._capture_observations(tensordict, input=True)
         try:
             self.input_schema.validate_inputs(tensordict)
             if self.interventions is not None:
                 tensordict = self.interventions.apply(self, tensordict, InterventionTiming.INPUT)
+            self._capture_observations(tensordict, input=True)
             result = (self.module if module is None else module)(tensordict)
         except BaseException as error:
             self._record(LifecycleEventType.FAILURE, tensordict, error)

--- a/src/xdrl/interventions.py
+++ b/src/xdrl/interventions.py
@@ -1,0 +1,281 @@
+"""Explicit, checked interventions for typed RL interactions.
+
+The public objects here describe *mechanics*, not causal conclusions.  A
+TensorDict intervention is applied by ``RuntimeInteractionContext`` while
+activation and gradient interventions are exposed as a TDHook factory.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import torch
+from tensordict import TensorDictBase
+from tdhook.contexts import HookingContextFactory
+from tdhook.hooks import MultiHookHandle, resolve_submodule_path
+from tdhook.modules import HookedModule
+
+from xdrl.types import KeyPresence, TensorDictKey, TensorDictSchema
+
+if TYPE_CHECKING:
+    from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext
+
+
+class InterventionTarget(str, Enum):
+    """The execution boundary an intervention edits."""
+
+    TENSORDICT = "tensordict"
+    ACTIVATION = "activation"
+    GRADIENT = "gradient"
+
+
+class InterventionTiming(str, Enum):
+    """Whether the value is edited before or after the selected boundary."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+
+
+class InterventionValidationError(ValueError):
+    """An intervention cannot safely be applied to an interaction."""
+
+
+TensorTransform = Callable[[torch.Tensor], torch.Tensor]
+InteractionPredicate = Callable[["InteractionDescriptor"], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class InterventionScope:
+    """Optional semantic constraints selecting supported interaction runs."""
+
+    phases: frozenset["InteractionPhase"] | None = None
+    roles: frozenset[Any] | None = None
+    environment: str | None = None
+    time_dimension: str | None = None
+    agent_dimension: str | None = None
+    exploration_mode: str | None = None
+    predicate: InteractionPredicate | None = field(default=None, compare=False, repr=False)
+
+    def matches(self, descriptor: "InteractionDescriptor") -> bool:
+        return (
+            (self.phases is None or descriptor.phase in self.phases)
+            and (self.roles is None or descriptor.role in self.roles)
+            and (self.environment is None or descriptor.environment == self.environment)
+            and (self.time_dimension is None or descriptor.time_dimension == self.time_dimension)
+            and (self.agent_dimension is None or descriptor.agent_dimension == self.agent_dimension)
+            and (self.exploration_mode is None or descriptor.exploration_mode == self.exploration_mode)
+            and (self.predicate is None or self.predicate(descriptor))
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Intervention:
+    """One replacement or transform at an explicit, checked target.
+
+    ``key`` is required for ``TENSORDICT`` interventions and ``module_path``
+    is required for TDHook activation and gradient interventions.  Exactly one
+    of ``replacement`` and ``transform`` must be supplied.
+    """
+
+    identifier: str
+    target: InterventionTarget
+    timing: InterventionTiming
+    replacement: torch.Tensor | None = field(default=None, repr=False, compare=False)
+    transform: TensorTransform | None = field(default=None, repr=False, compare=False)
+    key: TensorDictKey | None = None
+    module_path: str | None = None
+    scope: InterventionScope = field(default_factory=InterventionScope)
+
+    def __post_init__(self) -> None:
+        if not self.identifier:
+            raise InterventionValidationError("intervention identifier must be non-empty")
+        if (self.replacement is None) == (self.transform is None):
+            raise InterventionValidationError("provide exactly one of replacement or transform")
+        if self.target is InterventionTarget.TENSORDICT:
+            if self.key is None or self.module_path is not None:
+                raise InterventionValidationError("TensorDict interventions require key and forbid module_path")
+        elif self.module_path is None or self.key is not None:
+            raise InterventionValidationError(f"{self.target.value} interventions require module_path and forbid key")
+
+    def applies_to(self, descriptor: "InteractionDescriptor") -> bool:
+        return self.scope.matches(descriptor)
+
+    def edit_tensor(self, value: torch.Tensor, *, label: str) -> torch.Tensor:
+        result = self.replacement if self.replacement is not None else self.transform(value)  # type: ignore[misc]
+        if not isinstance(result, torch.Tensor):
+            raise InterventionValidationError(f"{self.identifier}: {label} transform must return a torch.Tensor")
+        if result.shape != value.shape or result.dtype != value.dtype or result.device != value.device:
+            raise InterventionValidationError(
+                f"{self.identifier}: {label} replacement must preserve shape={tuple(value.shape)!r}, "
+                f"dtype={value.dtype}, and device={value.device}; got shape={tuple(result.shape)!r}, "
+                f"dtype={result.dtype}, device={result.device}"
+            )
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class InterventionRecord:
+    """Tensor-free provenance for an intervention application."""
+
+    identifier: str
+    target: InterventionTarget
+    timing: InterventionTiming
+    interaction_id: str
+    checkpoint_id: str | None
+    order: int
+
+
+@dataclass(frozen=True, slots=True)
+class PairedInterventionResult:
+    """Outputs from matched control and intervention executions."""
+
+    interaction_id: str
+    checkpoint_id: str | None
+    baseline: TensorDictBase
+    intervention: TensorDictBase
+
+
+class InterventionController:
+    """Apply TensorDict edits and retain compact intervention provenance."""
+
+    def __init__(self, interventions: Iterable[Intervention] = ()) -> None:
+        self.interventions = tuple(interventions)
+        self.records: list[InterventionRecord] = []
+
+    def validate(self, interaction: "RuntimeInteractionContext") -> None:
+        for intervention in self.interventions:
+            if not intervention.applies_to(interaction.descriptor):
+                continue
+            if intervention.target is not InterventionTarget.TENSORDICT:
+                continue
+            schema = interaction.input_schema if intervention.timing is InterventionTiming.INPUT else interaction.output_schema
+            _validate_key(intervention, schema)
+
+    def apply(self, interaction: "RuntimeInteractionContext", tensordict: TensorDictBase, timing: InterventionTiming) -> TensorDictBase:
+        schema = interaction.input_schema if timing is InterventionTiming.INPUT else interaction.output_schema
+        for intervention in self.interventions:
+            if intervention.target is not InterventionTarget.TENSORDICT or intervention.timing is not timing:
+                continue
+            if not intervention.applies_to(interaction.descriptor):
+                continue
+            assert intervention.key is not None
+            value = tensordict.get(intervention.key)
+            if not isinstance(value, torch.Tensor):
+                raise InterventionValidationError(f"{intervention.identifier}: key {_display_key(intervention.key)} is not a tensor")
+            tensordict.set(intervention.key, intervention.edit_tensor(value, label=_display_key(intervention.key)))
+            # Revalidate immediately: this includes feature shape, batch semantics,
+            # device/dtype membership, and any TensorSpec constraint.
+            if timing is InterventionTiming.INPUT:
+                schema.validate_inputs(tensordict)
+            else:
+                schema.validate_outputs(tensordict)
+            self.records.append(
+                InterventionRecord(
+                    intervention.identifier,
+                    intervention.target,
+                    timing,
+                    interaction.descriptor.identity,
+                    interaction.descriptor.checkpoint_id,
+                    len(self.records),
+                )
+            )
+        return tensordict
+
+
+def run_paired(
+    baseline: "RuntimeInteractionContext",
+    intervention: "RuntimeInteractionContext",
+    tensordict: TensorDictBase,
+) -> PairedInterventionResult:
+    """Run matched baseline and intervention contexts over independent inputs.
+
+    The caller explicitly constructs both contexts, which keeps model ownership
+    and execution modes in TorchRL.  This helper only enforces the provenance
+    identity needed to compare their outputs safely.
+    """
+    baseline_descriptor = baseline.descriptor
+    intervention_descriptor = intervention.descriptor
+    if (
+        baseline_descriptor.identity != intervention_descriptor.identity
+        or baseline_descriptor.checkpoint_id != intervention_descriptor.checkpoint_id
+    ):
+        raise InterventionValidationError(
+            "paired executions must share interaction identity and checkpoint provenance"
+        )
+    with baseline:
+        baseline_output = baseline.invoke(tensordict.clone())
+    with intervention:
+        intervention_output = intervention.invoke(tensordict.clone())
+    return PairedInterventionResult(
+        baseline_descriptor.identity,
+        baseline_descriptor.checkpoint_id,
+        baseline_output,
+        intervention_output,
+    )
+
+
+class TDHookInterventionFactory(HookingContextFactory):
+    """Install activation/gradient edits through TDHook's managed lifecycle."""
+
+    def __init__(self, interaction: "RuntimeInteractionContext", interventions: Sequence[Intervention]) -> None:
+        super().__init__()
+        self._interaction = interaction
+        self._interventions = tuple(interventions)
+        for intervention in self._interventions:
+            if intervention.target is InterventionTarget.TENSORDICT:
+                raise InterventionValidationError("TDHookInterventionFactory accepts activation or gradient interventions only")
+            if intervention.applies_to(interaction.descriptor):
+                assert intervention.module_path is not None
+                try:
+                    resolve_submodule_path(interaction.module, intervention.module_path)
+                except ValueError as error:
+                    raise InterventionValidationError(
+                        f"{intervention.identifier}: cannot resolve TDHook target {intervention.module_path!r}"
+                    ) from error
+
+    def _hook_module(self, module: HookedModule) -> MultiHookHandle:
+        handles = []
+        for intervention in self._interventions:
+            if not intervention.applies_to(self._interaction.descriptor):
+                continue
+            assert intervention.module_path is not None
+            direction = _hook_direction(intervention)
+
+            def callback(
+                *, intervention: Intervention = intervention, direction: str = direction, **kwargs: Any
+            ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+                container = kwargs["output"] if direction == "fwd" else (
+                    kwargs["args"] if direction == "fwd_pre" else kwargs["grad_input"] if direction == "bwd" else kwargs["grad_output"]
+                )
+                value = container if isinstance(container, torch.Tensor) else container[-1]
+                if not isinstance(value, torch.Tensor):
+                    raise InterventionValidationError(
+                        f"{intervention.identifier}: TDHook target {intervention.module_path!r} did not receive a tensor"
+                    )
+                edited = intervention.edit_tensor(value, label=f"TDHook target {intervention.module_path}")
+                return edited if isinstance(container, torch.Tensor) else (*container[:-1], edited)
+
+            handles.append(module.set(intervention.module_path, None, callback=callback, direction=direction))
+        return MultiHookHandle(handles)
+
+
+def _validate_key(intervention: Intervention, schema: TensorDictSchema) -> None:
+    assert intervention.key is not None
+    expected = KeyPresence.REQUIRED if intervention.timing is InterventionTiming.INPUT else KeyPresence.PRODUCED
+    if not any(entry.key == intervention.key and entry.presence is expected for entry in schema.keys):
+        raise InterventionValidationError(
+            f"{intervention.identifier}: key {_display_key(intervention.key)} is not a declared {expected.value} key"
+        )
+
+
+def _hook_direction(intervention: Intervention) -> str:
+    if intervention.target is InterventionTarget.ACTIVATION:
+        return "fwd_pre" if intervention.timing is InterventionTiming.INPUT else "fwd"
+    return "bwd" if intervention.timing is InterventionTiming.INPUT else "bwd_pre"
+
+
+def _display_key(key: TensorDictKey) -> str:
+    return "/".join(key) if isinstance(key, tuple) else key

--- a/src/xdrl/interventions.py
+++ b/src/xdrl/interventions.py
@@ -213,10 +213,20 @@ def run_paired(
         raise InterventionValidationError(
             "paired executions must share interaction identity and checkpoint provenance"
         )
-    with baseline:
-        baseline_output = baseline.invoke(tensordict.clone())
-    with intervention:
-        intervention_output = intervention.invoke(tensordict.clone())
+    initial_rng_state = _rng_state()
+    post_baseline_rng_state = initial_rng_state
+    try:
+        with baseline:
+            baseline_output = baseline.invoke(tensordict.clone())
+        post_baseline_rng_state = _rng_state()
+        _set_rng_state(initial_rng_state)
+        with intervention:
+            intervention_output = intervention.invoke(tensordict.clone())
+    finally:
+        # A pair consumes the same random stream as one baseline invocation.
+        # This both matches stochastic executions and avoids leaking an extra
+        # random draw into the caller's next interaction.
+        _set_rng_state(post_baseline_rng_state)
     return PairedInterventionResult(
         baseline_descriptor.identity,
         baseline_descriptor.checkpoint_id,
@@ -237,14 +247,28 @@ class TDHookInterventionFactory(HookingContextFactory):
                 raise InterventionValidationError(
                     "TDHookInterventionFactory accepts activation or gradient interventions only"
                 )
-            if intervention.applies_to(interaction.descriptor):
-                assert intervention.module_path is not None
-                try:
-                    resolve_submodule_path(interaction.module, intervention.module_path)
-                except ValueError as error:
-                    raise InterventionValidationError(
-                        f"{intervention.identifier}: cannot resolve TDHook target {intervention.module_path!r}"
-                    ) from error
+            if (
+                intervention.applies_to(interaction.descriptor)
+                and intervention.target is InterventionTarget.GRADIENT
+                and (not interaction.descriptor.gradient_enabled or interaction.descriptor.inference_mode)
+            ):
+                raise InterventionValidationError(
+                    f"{intervention.identifier}: gradient interventions require gradient_enabled=True and inference_mode=False"
+                )
+
+    def prepare(self, module: Any, *args: Any, **kwargs: Any) -> Any:
+        """Validate paths against TDHook's selected module immediately before preparation."""
+        for intervention in self._interventions:
+            if not intervention.applies_to(self._interaction.descriptor):
+                continue
+            assert intervention.module_path is not None
+            try:
+                resolve_submodule_path(module, intervention.module_path)
+            except ValueError as error:
+                raise InterventionValidationError(
+                    f"{intervention.identifier}: cannot resolve TDHook target {intervention.module_path!r}"
+                ) from error
+        return super().prepare(module, *args, **kwargs)
 
     def _hook_module(self, module: HookedModule) -> MultiHookHandle:
         handles = []
@@ -268,13 +292,17 @@ class TDHookInterventionFactory(HookingContextFactory):
                         else kwargs["grad_output"]
                     )
                 )
-                value = container if isinstance(container, torch.Tensor) else container[-1]
-                if not isinstance(value, torch.Tensor):
+                if isinstance(container, torch.Tensor):
+                    return intervention.edit_tensor(container, label=f"TDHook target {intervention.module_path}")
+                tensor_indices = [index for index, value in enumerate(container) if isinstance(value, torch.Tensor)]
+                if len(tensor_indices) != 1:
                     raise InterventionValidationError(
-                        f"{intervention.identifier}: TDHook target {intervention.module_path!r} did not receive a tensor"
+                        f"{intervention.identifier}: TDHook target {intervention.module_path!r} received "
+                        f"{len(tensor_indices)} tensor values; select a module with one tensor input or output"
                     )
-                edited = intervention.edit_tensor(value, label=f"TDHook target {intervention.module_path}")
-                return edited if isinstance(container, torch.Tensor) else (*container[:-1], edited)
+                index = tensor_indices[0]
+                edited = intervention.edit_tensor(container[index], label=f"TDHook target {intervention.module_path}")
+                return (*container[:index], edited, *container[index + 1 :])
 
             handles.append(module.set(intervention.module_path, None, callback=callback, direction=direction))
         return MultiHookHandle(handles)
@@ -297,3 +325,14 @@ def _hook_direction(intervention: Intervention) -> str:
 
 def _display_key(key: TensorDictKey) -> str:
     return "/".join(key) if isinstance(key, tuple) else key
+
+
+def _rng_state() -> tuple[torch.Tensor, list[torch.Tensor] | None]:
+    """Snapshot CPU and, when present, every CUDA generator state."""
+    return torch.get_rng_state(), torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None
+
+
+def _set_rng_state(state: tuple[torch.Tensor, list[torch.Tensor] | None]) -> None:
+    torch.set_rng_state(state[0])
+    if state[1] is not None:
+        torch.cuda.set_rng_state_all(state[1])

--- a/src/xdrl/interventions.py
+++ b/src/xdrl/interventions.py
@@ -151,10 +151,16 @@ class InterventionController:
                 continue
             if intervention.target is not InterventionTarget.TENSORDICT:
                 continue
-            schema = interaction.input_schema if intervention.timing is InterventionTiming.INPUT else interaction.output_schema
+            schema = (
+                interaction.input_schema
+                if intervention.timing is InterventionTiming.INPUT
+                else interaction.output_schema
+            )
             _validate_key(intervention, schema)
 
-    def apply(self, interaction: "RuntimeInteractionContext", tensordict: TensorDictBase, timing: InterventionTiming) -> TensorDictBase:
+    def apply(
+        self, interaction: "RuntimeInteractionContext", tensordict: TensorDictBase, timing: InterventionTiming
+    ) -> TensorDictBase:
         schema = interaction.input_schema if timing is InterventionTiming.INPUT else interaction.output_schema
         for intervention in self.interventions:
             if intervention.target is not InterventionTarget.TENSORDICT or intervention.timing is not timing:
@@ -164,7 +170,9 @@ class InterventionController:
             assert intervention.key is not None
             value = tensordict.get(intervention.key)
             if not isinstance(value, torch.Tensor):
-                raise InterventionValidationError(f"{intervention.identifier}: key {_display_key(intervention.key)} is not a tensor")
+                raise InterventionValidationError(
+                    f"{intervention.identifier}: key {_display_key(intervention.key)} is not a tensor"
+                )
             tensordict.set(intervention.key, intervention.edit_tensor(value, label=_display_key(intervention.key)))
             # Revalidate immediately: this includes feature shape, batch semantics,
             # device/dtype membership, and any TensorSpec constraint.
@@ -226,7 +234,9 @@ class TDHookInterventionFactory(HookingContextFactory):
         self._interventions = tuple(interventions)
         for intervention in self._interventions:
             if intervention.target is InterventionTarget.TENSORDICT:
-                raise InterventionValidationError("TDHookInterventionFactory accepts activation or gradient interventions only")
+                raise InterventionValidationError(
+                    "TDHookInterventionFactory accepts activation or gradient interventions only"
+                )
             if intervention.applies_to(interaction.descriptor):
                 assert intervention.module_path is not None
                 try:
@@ -247,8 +257,16 @@ class TDHookInterventionFactory(HookingContextFactory):
             def callback(
                 *, intervention: Intervention = intervention, direction: str = direction, **kwargs: Any
             ) -> torch.Tensor | tuple[torch.Tensor, ...]:
-                container = kwargs["output"] if direction == "fwd" else (
-                    kwargs["args"] if direction == "fwd_pre" else kwargs["grad_input"] if direction == "bwd" else kwargs["grad_output"]
+                container = (
+                    kwargs["output"]
+                    if direction == "fwd"
+                    else (
+                        kwargs["args"]
+                        if direction == "fwd_pre"
+                        else kwargs["grad_input"]
+                        if direction == "bwd"
+                        else kwargs["grad_output"]
+                    )
                 )
                 value = container if isinstance(container, torch.Tensor) else container[-1]
                 if not isinstance(value, torch.Tensor):

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -260,6 +260,29 @@ def test_tensordict_interventions_are_checked_and_record_checkpoint_provenance()
     assert (record.interaction_id, record.checkpoint_id) == (descriptor.identity, "checkpoint-9")
 
 
+def test_paired_execution_reuses_randomness_for_a_no_op_intervention() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.ones(2, 2)}, batch_size=[2])
+    policy = TensorDictModule(torch.nn.Dropout(p=0.5), in_keys=["observation"], out_keys=["action"])
+    descriptor = _descriptor(InteractionPhase.EVALUATION, inputs, outputs)
+    no_op = Intervention(
+        "control",
+        InterventionTarget.TENSORDICT,
+        InterventionTiming.OUTPUT,
+        transform=lambda value: value.clone(),
+        key="action",
+    )
+    baseline = RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch)
+    control = RuntimeInteractionContext(
+        descriptor, policy, inputs, outputs, batch, interventions=InterventionController((no_op,))
+    )
+
+    torch.manual_seed(7)
+    result = run_paired(baseline, control, batch)
+
+    assert torch.equal(result.baseline.get("action"), result.intervention.get("action"))
+
+
 def test_invalid_tensordict_interventions_fail_at_the_contract_boundary() -> None:
     inputs, outputs = _schemas()
     batch = TensorDict({"observation": torch.ones(2, 2)}, batch_size=[2])

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -24,6 +24,7 @@ from xdrl.interventions import (
     InterventionValidationError,
     run_paired,
 )
+from xdrl.observations import ObservationTrace, RetentionPolicy, TensorRetention
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
 
@@ -324,3 +325,30 @@ def test_invalid_tensordict_interventions_fail_at_the_contract_boundary() -> Non
                 )
             ),
         )
+
+
+def test_input_observations_capture_the_intervened_value() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.ones(1, 2)}, batch_size=[1])
+    intervention = Intervention(
+        "zero-input",
+        InterventionTarget.TENSORDICT,
+        InterventionTiming.INPUT,
+        transform=torch.zeros_like,
+        key="observation",
+    )
+    trace = ObservationTrace(RetentionPolicy(tensor=TensorRetention.DETACHED))
+    context = RuntimeInteractionContext(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs),
+        _policy(),
+        inputs,
+        outputs,
+        batch,
+        observations=trace,
+        interventions=InterventionController((intervention,)),
+    )
+
+    with context:
+        context.invoke(batch.clone())
+
+    assert torch.equal(trace.records[0].payload, torch.zeros(1, 2))

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -16,6 +16,14 @@ from xdrl.interactions import (
     RuntimeInteractionContext,
     SchemaSnapshot,
 )
+from xdrl.interventions import (
+    Intervention,
+    InterventionController,
+    InterventionTarget,
+    InterventionTiming,
+    InterventionValidationError,
+    run_paired,
+)
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
 
@@ -209,3 +217,87 @@ def test_output_validation_failure_reports_output_shapes() -> None:
 
     assert context.events[-1].kind is LifecycleEventType.FAILURE
     assert context.events[-1].key_shapes == {"unexpected": (2, 3)}
+
+
+def test_tensordict_interventions_are_checked_and_record_checkpoint_provenance() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.ones(2, 2)}, batch_size=[2])
+    descriptor = replace(_descriptor(InteractionPhase.EVALUATION, inputs, outputs), checkpoint_id="checkpoint-9")
+    no_op = Intervention(
+        "control",
+        InterventionTarget.TENSORDICT,
+        InterventionTiming.OUTPUT,
+        transform=lambda value: value.clone(),
+        key="action",
+    )
+    changed = Intervention(
+        "steer",
+        InterventionTarget.TENSORDICT,
+        InterventionTiming.OUTPUT,
+        transform=lambda value: value + 1,
+        key="action",
+    )
+    policy = _policy()
+    with torch.no_grad():
+        policy.module.weight.zero_()
+    baseline = RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch)
+    control = RuntimeInteractionContext(
+        descriptor, policy, inputs, outputs, batch, interventions=InterventionController((no_op,))
+    )
+    steered = RuntimeInteractionContext(
+        descriptor, policy, inputs, outputs, batch, interventions=InterventionController((changed,))
+    )
+
+    control_result = run_paired(baseline, control, batch)
+    result = run_paired(baseline, steered, batch)
+    expected = control_result.baseline.get("action")
+    assert torch.equal(control_result.intervention.get("action"), expected)
+    actual = result.intervention.get("action")
+
+    assert torch.equal(actual, expected + 1)
+    assert (result.interaction_id, result.checkpoint_id) == (descriptor.identity, "checkpoint-9")
+    record = steered.interventions.records[0]
+    assert (record.interaction_id, record.checkpoint_id) == (descriptor.identity, "checkpoint-9")
+
+
+def test_invalid_tensordict_interventions_fail_at_the_contract_boundary() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.ones(2, 2)}, batch_size=[2])
+    invalid = Intervention(
+        "bad-shape",
+        InterventionTarget.TENSORDICT,
+        InterventionTiming.INPUT,
+        transform=lambda value: value[..., :1],
+        key="observation",
+    )
+    context = RuntimeInteractionContext(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs),
+        _policy(),
+        inputs,
+        outputs,
+        batch,
+        interventions=InterventionController((invalid,)),
+    )
+
+    with context, pytest.raises(InterventionValidationError, match="must preserve shape"):
+        context.invoke(batch.clone())
+
+    with pytest.raises(InterventionValidationError, match="declared required key"):
+        RuntimeInteractionContext(
+            _descriptor(InteractionPhase.EVALUATION, inputs, outputs),
+            _policy(),
+            inputs,
+            outputs,
+            batch,
+            interventions=InterventionController(
+                (
+                    Intervention(
+                        "bad-key",
+                        InterventionTarget.TENSORDICT,
+                        InterventionTiming.INPUT,
+                        replacement=torch.ones(2, 2),
+                        key="missing",
+                    ),
+                )
+            ),
+        )

--- a/tests/unit/test_tdhook.py
+++ b/tests/unit/test_tdhook.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 import torch
 from tensordict import TensorDict
@@ -158,6 +160,31 @@ def test_gradient_intervention_requires_an_autograd_enabled_interaction() -> Non
 
     with pytest.raises(InterventionValidationError, match="gradient_enabled=True"):
         TDHookInterventionFactory(interaction, (intervention,))
+
+
+@pytest.mark.parametrize("timing", [InterventionTiming.INPUT, InterventionTiming.OUTPUT])
+def test_gradient_interventions_replace_backpropagated_input_gradients(timing: InterventionTiming) -> None:
+    policy = _policy()
+    interaction = _interaction(policy)
+    interaction.descriptor = replace(interaction.descriptor, gradient_enabled=True)
+    batch = interaction.representative_input.clone()
+    observation = batch.get(("agents", "observation")).requires_grad_()
+    batch.set(("agents", "observation"), observation)
+    intervention = Intervention(
+        f"zero-gradient-{timing.value}",
+        InterventionTarget.GRADIENT,
+        timing,
+        transform=torch.zeros_like,
+        module_path="module",
+    )
+    adapter = TDHookInteractionAdapter(interaction)
+    factory = TDHookInterventionFactory(interaction, (intervention,))
+
+    with adapter.activate(factory) as active:
+        active.invoke(batch).get(("agents", "action")).sum().backward()
+
+    assert observation.grad is not None
+    assert torch.equal(observation.grad, torch.zeros_like(observation))
 
 
 def test_intervention_paths_are_resolved_against_the_adapter_selection() -> None:

--- a/tests/unit/test_tdhook.py
+++ b/tests/unit/test_tdhook.py
@@ -5,6 +5,7 @@ from tensordict.nn import TensorDictModule
 from tdhook.latent.activation_caching import ActivationCaching
 
 from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext, SchemaSnapshot
+from xdrl.interventions import Intervention, InterventionTarget, InterventionTiming, TDHookInterventionFactory
 from xdrl.tdhook import TDHookInteractionAdapter
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
@@ -116,4 +117,24 @@ def test_adapter_removes_hooks_when_invocation_fails() -> None:
     with pytest.raises(RuntimeError, match="boom"):
         with adapter.activate(factory):
             raise RuntimeError("boom")
+    assert not policy.module._forward_hooks
+
+
+def test_tdhook_activation_intervention_changes_output_and_removes_its_hook() -> None:
+    policy = _policy()
+    interaction = _interaction(policy)
+    intervention = Intervention(
+        "zero-head",
+        InterventionTarget.ACTIVATION,
+        InterventionTiming.OUTPUT,
+        transform=torch.zeros_like,
+        module_path="module",
+    )
+    adapter = TDHookInteractionAdapter(interaction)
+    factory = TDHookInterventionFactory(interaction, (intervention,))
+
+    with adapter.activate(factory) as active:
+        result = active.invoke(interaction.representative_input.clone())
+        assert torch.equal(result.get(("agents", "action")), torch.zeros(3, 2, 1))
+
     assert not policy.module._forward_hooks

--- a/tests/unit/test_tdhook.py
+++ b/tests/unit/test_tdhook.py
@@ -5,7 +5,13 @@ from tensordict.nn import TensorDictModule
 from tdhook.latent.activation_caching import ActivationCaching
 
 from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext, SchemaSnapshot
-from xdrl.interventions import Intervention, InterventionTarget, InterventionTiming, TDHookInterventionFactory
+from xdrl.interventions import (
+    Intervention,
+    InterventionTarget,
+    InterventionTiming,
+    InterventionValidationError,
+    TDHookInterventionFactory,
+)
 from xdrl.tdhook import TDHookInteractionAdapter
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
@@ -138,3 +144,65 @@ def test_tdhook_activation_intervention_changes_output_and_removes_its_hook() ->
         assert torch.equal(result.get(("agents", "action")), torch.zeros(3, 2, 1))
 
     assert not policy.module._forward_hooks
+
+
+def test_gradient_intervention_requires_an_autograd_enabled_interaction() -> None:
+    interaction = _interaction(_policy())
+    intervention = Intervention(
+        "zero-gradient",
+        InterventionTarget.GRADIENT,
+        InterventionTiming.INPUT,
+        transform=torch.zeros_like,
+        module_path="module",
+    )
+
+    with pytest.raises(InterventionValidationError, match="gradient_enabled=True"):
+        TDHookInterventionFactory(interaction, (intervention,))
+
+
+def test_intervention_paths_are_resolved_against_the_adapter_selection() -> None:
+    interaction = _interaction(_policy())
+    selected = TensorDictModule(
+        torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.Linear(2, 1)),
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "action")],
+    )
+    intervention = Intervention(
+        "selected-head",
+        InterventionTarget.ACTIVATION,
+        InterventionTiming.OUTPUT,
+        transform=torch.zeros_like,
+        module_path="module.1",
+    )
+    adapter = TDHookInteractionAdapter(interaction, selected_module=selected)
+    factory = TDHookInterventionFactory(interaction, (intervention,))
+
+    with adapter.activate(factory) as active:
+        result = active.invoke(interaction.representative_input.clone())
+        assert torch.equal(result.get(("agents", "action")), torch.zeros(3, 2, 1))
+
+
+class _TwoTensorOutputs(torch.nn.Module):
+    def forward(self, value: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return value[..., :1], value[..., :1]
+
+
+def test_tdhook_intervention_rejects_ambiguous_multi_tensor_outputs() -> None:
+    policy = TensorDictModule(
+        _TwoTensorOutputs(),
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "action"), ("agents", "auxiliary")],
+    )
+    interaction = _interaction(policy)
+    intervention = Intervention(
+        "ambiguous",
+        InterventionTarget.ACTIVATION,
+        InterventionTiming.OUTPUT,
+        transform=torch.zeros_like,
+        module_path="module",
+    )
+    adapter = TDHookInteractionAdapter(interaction)
+    factory = TDHookInterventionFactory(interaction, (intervention,))
+
+    with adapter.activate(factory), pytest.raises(InterventionValidationError, match="2 tensor values"):
+        adapter.invoke(interaction.representative_input.clone())


### PR DESCRIPTION
## Summary

- add typed, scoped TensorDict, activation, and gradient intervention definitions
- validate replacements at the execution boundary and record tensor-free intervention provenance
- expose matched baseline/intervention execution and TDHook-managed activation hooks with cleanup

## Why

Implements the mechanics requested by #20 while preserving TorchRL TensorDict execution and TDHook lifecycle ownership.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -q` (46 passed; 74.46% total coverage)

Closes #20.