### PR TITLE
Integrate typed observability at TorchRL execution boundaries

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -47,6 +47,8 @@ without changing TorchRL's collector or trainer loops. An
 the role, phase, module path, declared I/O schemas, batch semantics,
 exploration/gradient/autocast configuration, and any supplied logical
 step/episode/trajectory identifiers. It contains neither tensors nor modules.
+``module_training`` optionally requests train or evaluation mode for the live
+call; the exact pre-existing mode of every submodule is restored afterwards.
 
 ``RuntimeInteractionContext`` is the matching ephemeral wrapper. Its
 construction checks a representative input against the declared input schema;
@@ -56,6 +58,62 @@ hook context even if the invocation raises. Its ordered ``before``, ``after``,
 and ``failure`` records retain only phase, module path, error text, and key
 shapes. An interaction identity must be stable within an execution record;
 event order is increasing within that identity.
+
+Execution-boundary support
+--------------------------
+
+The context itself is a one-shot callable, so a direct call and a local
+``SyncDataCollector`` policy can use the same object. It does not own a
+collector, rollout, replay buffer, optimiser, or trainer schedule.
+
+.. list-table:: Support matrix
+   :header-rows: 1
+
+   * - Boundary
+     - Typical model role
+     - TensorDict available
+     - Gradients available
+     - Lifecycle guarantee
+   * - Direct call
+     - Any
+     - Caller input/output
+     - Descriptor-controlled
+     - One before/after or failure pair per call
+   * - Synchronous collection
+     - Actor
+     - Current env step
+     - Normally disabled
+     - Main-process policy calls only
+   * - Evaluation rollout
+     - Actor/value
+     - Current env step
+     - Normally disabled
+     - Exploration and exact module modes restored
+   * - Replay-batch loss
+     - Loss/critic/value
+     - Sampled replay batch
+     - Usually enabled
+     - Context covers the loss-module call
+   * - Target/value estimate
+     - Value/critic
+     - Loss working batch
+     - Usually disabled
+     - Separate target interaction identity
+   * - Backward/optimisation
+     - Loss
+     - Loss output and gradients
+     - Enabled when requested
+     - Hooks live only while the context remains open
+
+For backward-time gradient observation, use the explicit context form and call
+``backward`` before leaving it. The one-shot callable necessarily removes
+temporary hooks after the forward call returns. Optimiser stepping remains a
+trainer responsibility and does not create a model invocation by itself.
+
+Only local synchronous calls are supported. Hooks installed in the main
+process are not propagated to worker copies. Multiprocessing and distributed
+collectors, compiled modules, and CUDA graphs are unsupported until their
+copying and lifecycle semantics are tested explicitly.
 
 Observation traces
 ------------------

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,4 +1,56 @@
 Tutorials
 =========
 
-TBD.
+TorchRL execution boundaries
+-----------------------------
+
+Build one ``RuntimeInteractionContext`` for each semantic model invocation.
+The descriptor distinguishes collection, evaluation, loss, and target calls;
+the live TensorDict remains owned by TorchRL. Assuming ``collection`` is a
+context whose descriptor has phase ``COLLECTION``, direct execution is simply::
+
+    action_td = collection(step_td)
+
+The same callable can be passed as the policy of a local synchronous
+collector. XDRL neither changes the returned keys nor controls batching::
+
+    from torchrl.collectors import SyncDataCollector
+
+    collector = SyncDataCollector(
+        env,
+        policy=collection,
+        frames_per_batch=256,
+        total_frames=10_000,
+    )
+    for rollout in collector:
+        replay_buffer.extend(rollout)
+
+Do not use this pattern with a collector that copies the policy into workers.
+Hooks registered in the main process are not claimed to exist in those copies.
+
+For deterministic evaluation, use a distinct descriptor with
+``phase=InteractionPhase.EVALUATION``, ``exploration_mode="deterministic"``,
+and ``module_training=False``. Both exploration state and the exact train/eval
+flags of the module tree are restored after every call, including failures::
+
+    with torch.no_grad():
+        evaluation_rollout = env.rollout(1_000, policy=evaluation)
+
+A replay-batch loss module uses the same invocation API. If activation hooks
+only need the forward pass, the one-shot form is sufficient::
+
+    loss_td = replay_loss(replay_buffer.sample())
+
+When gradient hooks must observe backward, keep the interaction open until
+backward completes. The descriptor should use ``phase=InteractionPhase.LOSS``
+or ``OPTIMISATION`` and ``gradient_enabled=True``::
+
+    optimiser.zero_grad()
+    with replay_loss:
+        loss_td = replay_loss.invoke(replay_buffer.sample())
+        loss_td["loss_objective"].backward()
+    optimiser.step()
+
+Target/value estimation should use its own ``TARGET`` descriptor and identity,
+even when it invokes a module with shared parameters. Logging, checkpointing,
+replay sampling, and optimiser scheduling stay outside the interaction.

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -115,6 +115,7 @@ class InteractionDescriptor:
     module_aliases: Mapping[str, str] = field(default_factory=dict)
     model_id: str | None = None
     checkpoint_id: str | None = None
+    module_training: bool | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible representation with no tensors or modules."""
@@ -179,6 +180,12 @@ class RuntimeInteractionContext:
             raise RuntimeError("interaction context is already active")
         stack = ExitStack()
         try:
+            if self.descriptor.module_training is not None:
+                if not isinstance(self.module, torch.nn.Module):
+                    raise TypeError("module_training requires the interaction module to be a torch.nn.Module")
+                training_states = tuple((module, module.training) for module in self.module.modules())
+                stack.callback(_restore_training_states, training_states)
+                self.module.train(self.descriptor.module_training)
             if self.descriptor.exploration_mode is not None:
                 stack.enter_context(set_exploration_type(self.descriptor.exploration_mode))
             stack.enter_context(torch.inference_mode(self.descriptor.inference_mode))
@@ -198,6 +205,17 @@ class RuntimeInteractionContext:
             raise
         self._stack = stack
         return self
+
+    def __call__(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Run one interaction, making the context usable as a synchronous policy.
+
+        This one-shot form is suitable for direct calls, deterministic rollouts,
+        and local :class:`~torchrl.collectors.SyncDataCollector` policies. Keep
+        the context open explicitly when hooks must remain installed through a
+        subsequent backward pass.
+        """
+        with self:
+            return self.invoke(tensordict)
 
     def __exit__(self, *exc_info: object) -> bool | None:
         if self._stack is None:
@@ -262,6 +280,12 @@ class RuntimeInteractionContext:
 
 def _key_path(key: TensorDictKey) -> tuple[str, ...]:
     return tuple(str(part) for part in key) if isinstance(key, tuple) else (str(key),)
+
+
+def _restore_training_states(states: tuple[tuple[torch.nn.Module, bool], ...]) -> None:
+    """Restore the exact training flag of every submodule in a module tree."""
+    for module, training in states:
+        module.training = training
 
 
 def _key_shapes(tensordict: TensorDictBase) -> dict[str, tuple[int, ...] | None]:

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -181,11 +181,7 @@ class RuntimeInteractionContext:
         stack = ExitStack()
         try:
             if self.descriptor.module_training is not None:
-                if not isinstance(self.module, torch.nn.Module):
-                    raise TypeError("module_training requires the interaction module to be a torch.nn.Module")
-                training_states = tuple((module, module.training) for module in self.module.modules())
-                stack.callback(_restore_training_states, training_states)
-                self.module.train(self.descriptor.module_training)
+                _set_training_mode(stack, self.module, self.descriptor.module_training)
             if self.descriptor.exploration_mode is not None:
                 stack.enter_context(set_exploration_type(self.descriptor.exploration_mode))
             stack.enter_context(torch.inference_mode(self.descriptor.inference_mode))
@@ -227,13 +223,16 @@ class RuntimeInteractionContext:
         """Invoke the wrapped module and append before/after/failure events."""
         if self._stack is None:
             raise RuntimeError("invoke must be called inside the interaction context")
+        invoked_module = self.module if module is None else module
+        if module is not None and module is not self.module and self.descriptor.module_training is not None:
+            _set_training_mode(self._stack, invoked_module, self.descriptor.module_training)
         self._record(LifecycleEventType.BEFORE, tensordict)
         try:
             self.input_schema.validate_inputs(tensordict)
             if self.interventions is not None:
                 tensordict = self.interventions.apply(self, tensordict, InterventionTiming.INPUT)
             self._capture_observations(tensordict, input=True)
-            result = (self.module if module is None else module)(tensordict)
+            result = invoked_module(tensordict)
         except BaseException as error:
             self._record(LifecycleEventType.FAILURE, tensordict, error)
             raise
@@ -286,6 +285,15 @@ def _restore_training_states(states: tuple[tuple[torch.nn.Module, bool], ...]) -
     """Restore the exact training flag of every submodule in a module tree."""
     for module, training in states:
         module.training = training
+
+
+def _set_training_mode(stack: ExitStack, module: object, training: bool) -> None:
+    """Apply a temporary mode to the module tree actually used for execution."""
+    if not isinstance(module, torch.nn.Module):
+        raise TypeError("module_training requires the invoked module to be a torch.nn.Module")
+    training_states = tuple((child, child.training) for child in module.modules())
+    stack.callback(_restore_training_states, training_states)
+    module.train(training)
 
 
 def _key_shapes(tensordict: TensorDictBase) -> dict[str, tuple[int, ...] | None]:

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -106,6 +106,54 @@ def test_context_restores_execution_and_hook_state_after_exception() -> None:
     assert entered == ["entered", "exited"]
 
 
+def test_one_shot_call_is_a_synchronous_policy_and_restores_model_mode() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(2, 2)}, batch_size=[2])
+    policy = _policy()
+    policy.train()
+    descriptor = replace(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs),
+        module_training=False,
+    )
+    observed_modes: list[bool] = []
+    original_forward = policy.module.forward
+
+    def record_mode(value: torch.Tensor) -> torch.Tensor:
+        observed_modes.append(policy.training)
+        return original_forward(value)
+
+    policy.module.forward = record_mode
+    context = RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch)
+
+    result = context(batch.clone())
+
+    assert set(result.keys()) == {"observation", "action"}
+    assert observed_modes == [False]
+    assert policy.training
+    assert [event.kind for event in context.events] == [LifecycleEventType.BEFORE, LifecycleEventType.AFTER]
+
+
+def test_context_restores_mixed_submodule_modes_after_failure() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
+    policy = _policy()
+    policy.train()
+    policy.module.eval()
+    original_modes = tuple(module.training for module in policy.modules())
+    descriptor = replace(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs),
+        module_training=False,
+    )
+    context = RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with context:
+            assert all(not module.training for module in policy.modules())
+            raise RuntimeError("boom")
+
+    assert tuple(module.training for module in policy.modules()) == original_modes
+
+
 def test_context_enables_gradients_inside_outer_inference_mode() -> None:
     inputs, outputs = _schemas()
     batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
@@ -185,6 +233,20 @@ class _FailingPolicy:
 class _InvalidOutputPolicy:
     def __call__(self, tensordict: TensorDict) -> TensorDict:
         return TensorDict({"unexpected": torch.zeros(*tensordict.batch_size, 3)}, batch_size=tensordict.batch_size)
+
+
+def test_module_mode_requires_a_torch_module() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
+    descriptor = replace(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs),
+        module_training=False,
+    )
+    context = RuntimeInteractionContext(descriptor, _FailingPolicy(), inputs, outputs, batch)
+
+    with pytest.raises(TypeError, match="torch.nn.Module"):
+        with context:
+            pass
 
 
 def test_failure_event_retains_only_diagnostics() -> None:

--- a/tests/unit/test_interactions.py
+++ b/tests/unit/test_interactions.py
@@ -154,6 +154,37 @@ def test_context_restores_mixed_submodule_modes_after_failure() -> None:
     assert tuple(module.training for module in policy.modules()) == original_modes
 
 
+def test_context_applies_and_restores_mode_on_an_invocation_override() -> None:
+    inputs, outputs = _schemas()
+    batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
+    wrapped_policy = _policy()
+    override = _policy()
+    wrapped_policy.train()
+    override.train()
+    observed_modes: list[bool] = []
+    original_forward = override.module.forward
+
+    def record_mode(value: torch.Tensor) -> torch.Tensor:
+        observed_modes.append(override.training)
+        return original_forward(value)
+
+    override.module.forward = record_mode
+    descriptor = replace(
+        _descriptor(InteractionPhase.EVALUATION, inputs, outputs),
+        module_training=False,
+    )
+    context = RuntimeInteractionContext(descriptor, wrapped_policy, inputs, outputs, batch)
+
+    with context:
+        context.invoke(batch.clone(), module=override)
+        assert not wrapped_policy.training
+        assert not override.training
+
+    assert observed_modes == [False]
+    assert wrapped_policy.training
+    assert override.training
+
+
 def test_context_enables_gradients_inside_outer_inference_mode() -> None:
     inputs, outputs = _schemas()
     batch = TensorDict({"observation": torch.zeros(1, 2)}, batch_size=[1])
@@ -244,7 +275,7 @@ def test_module_mode_requires_a_torch_module() -> None:
     )
     context = RuntimeInteractionContext(descriptor, _FailingPolicy(), inputs, outputs, batch)
 
-    with pytest.raises(TypeError, match="torch.nn.Module"):
+    with pytest.raises(TypeError, match="invoked module"):
         with context:
             pass
 

--- a/tests/unit/test_tdhook.py
+++ b/tests/unit/test_tdhook.py
@@ -189,11 +189,13 @@ def test_gradient_interventions_replace_backpropagated_input_gradients(timing: I
 
 def test_intervention_paths_are_resolved_against_the_adapter_selection() -> None:
     interaction = _interaction(_policy())
+    interaction.descriptor = replace(interaction.descriptor, module_training=False)
     selected = TensorDictModule(
         torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.Linear(2, 1)),
         in_keys=[("agents", "observation")],
         out_keys=[("agents", "action")],
     )
+    selected.train()
     intervention = Intervention(
         "selected-head",
         InterventionTarget.ACTIVATION,
@@ -207,6 +209,9 @@ def test_intervention_paths_are_resolved_against_the_adapter_selection() -> None
     with adapter.activate(factory) as active:
         result = active.invoke(interaction.representative_input.clone())
         assert torch.equal(result.get(("agents", "action")), torch.zeros(3, 2, 1))
+        assert not selected.training
+
+    assert selected.training
 
 
 class _TwoTensorOutputs(torch.nn.Module):


### PR DESCRIPTION
Closes #21.

## What changed

- make `RuntimeInteractionContext` a one-shot callable suitable for direct calls, deterministic rollouts, and local synchronous collector policies
- add descriptor-controlled module train/eval mode with exact restoration of every submodule state, including exceptional exits
- document the support matrix for direct, collection, evaluation, replay/loss, target/value, and backward/optimisation boundaries
- document the main-process-only guarantee and explicitly unsupported multiprocessing, distributed, compiled, and CUDA-graph paths
- add focused tests for callable execution, unchanged TensorDict keys, model-mode restoration, and invalid non-module mode requests

## Why

TorchRL should continue to own collectors, rollouts, replay, optimisation, and scheduling. XDRL now supplies a typed observability boundary that can be embedded at those natural call sites without introducing a replacement trainer or mutating collector TensorDict structure.

## Validation

- `just checks`
- `just tests` — 56 passed, 75.35% coverage
- `uv run --group docs sphinx-build -W --keep-going docs/source build/docs`
- local `SyncDataCollector` smoke test — two collected frames with lifecycle events recorded on the original main-process interaction
