### PR TITLE
Type recurrent and multi-agent TorchRL interactions

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -115,6 +115,26 @@ process are not propagated to worker copies. Multiprocessing and distributed
 collectors, compiled modules, and CUDA graphs are unsupported until their
 copying and lifecycle semantics are tested explicitly.
 
+Recurrent and multi-agent semantics
+-----------------------------------
+
+``RecurrentSemantics`` maps each current recurrent-state key to its produced
+``next`` key, names boolean reset masks, and records the time axis, burn-in,
+truncated window, and collector mode. Direct calls, synchronous collection,
+and replay sequences are the supported state lifecycles. Multiprocess,
+asynchronous, and distributed recurrent collectors fail at contract creation
+instead of implying that state and hooks propagate to worker copies.
+
+``MultiAgentSemantics`` separates implementation paths from semantic targets.
+It records independent, parameter-shared, centralised-critic, or mixer
+topology together with the TorchRL group, agent count, and a
+``SemanticTarget`` made from a model role and ``AgentSelector``. In
+particular, a shared policy path cannot stand in for a per-agent identity:
+targeting one or more agents is expressed only by the selector. Centralised
+critics use critic/value roles, and mixers use the mixer role. VMAS-style
+``("agents", ...)`` keys remain native TensorDict nested keys; the agent axis
+is named separately from environment and time batch axes.
+
 Observation traces
 ------------------
 
@@ -129,10 +149,12 @@ the optional tensor payload.
 
 ``RetentionPolicy`` makes retention explicit: metadata-only is the default;
 detached or CPU snapshots clone their values and never retain computation
-graphs. Sampling and named ``mean``, ``sum``, or ``max`` batch reductions are
-opt-in. ``max_records`` plus an overflow policy bounds memory, while an
-optional callback supports streaming consumers. Probes and attribution remain
-external consumers of these records rather than becoming xdrl algorithms.
+graphs. Sampling is opt-in. Each ``DimensionReduction`` pairs an explicit
+batch-dimension name (such as ``time`` or ``agent``) with a serialised
+``mean``, ``sum``, or ``max`` policy; dimensions are preserved by default.
+``max_records`` plus an overflow policy bounds memory, while an optional
+callback supports streaming consumers. Probes and attribution remain external
+consumers of these records rather than becoming xdrl algorithms.
 
 TDHook instrumentation
 ----------------------

--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -1,6 +1,17 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext
+from xdrl.interactions import (
+    AgentSelector,
+    InteractionDescriptor,
+    InteractionPhase,
+    InteractionTopology,
+    MultiAgentSemantics,
+    RecurrentCollectorMode,
+    RecurrentSemantics,
+    RecurrentStateTransition,
+    RuntimeInteractionContext,
+    SemanticTarget,
+)
 from xdrl.interventions import (
     Intervention,
     InterventionController,
@@ -13,7 +24,15 @@ from xdrl.interventions import (
     TDHookInterventionFactory,
     run_paired,
 )
-from xdrl.observations import ObservationKind, ObservationRecord, ObservationTrace, RetentionPolicy, TensorRetention
+from xdrl.observations import (
+    DimensionReduction,
+    ObservationKind,
+    ObservationRecord,
+    ObservationTrace,
+    ReductionKind,
+    RetentionPolicy,
+    TensorRetention,
+)
 from xdrl.tdhook import TDHookInteractionAdapter
 from xdrl.types import ModelRole, TensorDictSchema
 
@@ -24,6 +43,7 @@ except PackageNotFoundError:
 
 __all__ = [
     "InteractionDescriptor",
+    "InteractionTopology",
     "Intervention",
     "InterventionController",
     "InterventionRecord",
@@ -32,12 +52,20 @@ __all__ = [
     "InterventionTiming",
     "InterventionValidationError",
     "InteractionPhase",
+    "AgentSelector",
+    "MultiAgentSemantics",
     "ModelRole",
     "ObservationKind",
     "ObservationRecord",
     "ObservationTrace",
+    "DimensionReduction",
+    "ReductionKind",
+    "RecurrentCollectorMode",
+    "RecurrentSemantics",
+    "RecurrentStateTransition",
     "RetentionPolicy",
     "RuntimeInteractionContext",
+    "SemanticTarget",
     "PairedInterventionResult",
     "TDHookInteractionAdapter",
     "TDHookInterventionFactory",

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -45,6 +45,109 @@ class LifecycleEventType(str, Enum):
     FAILURE = "failure"
 
 
+class InteractionTopology(str, Enum):
+    """How a multi-agent module relates parameters and semantic agents."""
+
+    INDEPENDENT = "independent"
+    PARAMETER_SHARED = "parameter_shared"
+    CENTRALISED_CRITIC = "centralised_critic"
+    MIXER = "mixer"
+
+
+class RecurrentCollectorMode(str, Enum):
+    """Collector execution modes whose recurrent state lifecycle is known."""
+
+    DIRECT = "direct"
+    SYNC = "sync"
+    REPLAY_SEQUENCE = "replay_sequence"
+    MULTIPROCESS = "multiprocess"
+    ASYNC = "async"
+    DISTRIBUTED = "distributed"
+
+
+@dataclass(frozen=True, slots=True)
+class RecurrentStateTransition:
+    """One recurrent state key consumed now and produced for the next step."""
+
+    input_key: tuple[str, ...]
+    output_key: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RecurrentSemantics:
+    """Serializable recurrent state, reset, and sequence-window semantics."""
+
+    transitions: tuple[RecurrentStateTransition, ...]
+    reset_keys: tuple[tuple[str, ...], ...]
+    sequence_dimension: str | None = None
+    burn_in: int = 0
+    truncated_window: int | None = None
+    collector_mode: RecurrentCollectorMode = RecurrentCollectorMode.DIRECT
+
+    def __post_init__(self) -> None:
+        if not self.transitions:
+            raise ValueError("recurrent semantics require at least one state transition")
+        if self.burn_in < 0:
+            raise ValueError("burn_in must be non-negative")
+        if self.truncated_window is not None and self.truncated_window < 1:
+            raise ValueError("truncated_window must be positive")
+        if self.truncated_window is not None and self.burn_in >= self.truncated_window:
+            raise ValueError("burn_in must be smaller than truncated_window")
+        supported = {
+            RecurrentCollectorMode.DIRECT,
+            RecurrentCollectorMode.SYNC,
+            RecurrentCollectorMode.REPLAY_SEQUENCE,
+        }
+        if self.collector_mode not in supported:
+            raise NotImplementedError(
+                f"recurrent collector mode {self.collector_mode.value!r} is unsupported; "
+                "only direct, sync, and replay_sequence state lifecycles are validated"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSelector:
+    """A semantic group selection, independent of the implementing module path."""
+
+    group: str
+    agents: tuple[str | int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.group:
+            raise ValueError("agent selector group must be non-empty")
+        if len(set(self.agents)) != len(self.agents):
+            raise ValueError("agent selector contains duplicate agents")
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticTarget:
+    """Target a model role and agent group without treating paths as identities."""
+
+    role: ModelRole
+    selector: AgentSelector
+
+
+@dataclass(frozen=True, slots=True)
+class MultiAgentSemantics:
+    """Serializable multi-agent topology and semantic target."""
+
+    topology: InteractionTopology
+    group: str
+    n_agents: int
+    target: SemanticTarget
+
+    def __post_init__(self) -> None:
+        if not self.group:
+            raise ValueError("multi-agent group must be non-empty")
+        if self.n_agents < 1:
+            raise ValueError("n_agents must be positive")
+        if self.target.selector.group != self.group:
+            raise ValueError("semantic target group must match the multi-agent group")
+        for agent in self.target.selector.agents:
+            if isinstance(agent, int) and not 0 <= agent < self.n_agents:
+                raise ValueError(f"agent index {agent} is outside the declared group size {self.n_agents}")
+
+
 @dataclass(frozen=True, slots=True)
 class KeySnapshot:
     """Serialisable description of one declared TensorDict key."""
@@ -116,6 +219,14 @@ class InteractionDescriptor:
     model_id: str | None = None
     checkpoint_id: str | None = None
     module_training: bool | None = None
+    recurrent: RecurrentSemantics | None = None
+    multi_agent: MultiAgentSemantics | None = None
+
+    def __post_init__(self) -> None:
+        if self.recurrent is not None:
+            _validate_recurrent_descriptor(self)
+        if self.multi_agent is not None:
+            _validate_multi_agent_descriptor(self)
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible representation with no tensors or modules."""
@@ -172,6 +283,7 @@ class RuntimeInteractionContext:
         if SchemaSnapshot.from_schema(self.output_schema) != self.descriptor.output_schema:
             raise ValueError("output_schema does not match the interaction descriptor snapshot")
         self.input_schema.validate_inputs(self.representative_input)
+        self._validate_recurrent_input(self.representative_input)
         if self.interventions is not None:
             self.interventions.validate(self)
 
@@ -238,6 +350,7 @@ class RuntimeInteractionContext:
             raise
         try:
             self.output_schema.validate_outputs(result)
+            self._validate_recurrent_output(tensordict, result)
             if self.interventions is not None:
                 result = self.interventions.apply(self, result, InterventionTiming.OUTPUT)
         except BaseException as error:
@@ -246,6 +359,30 @@ class RuntimeInteractionContext:
         self._record(LifecycleEventType.AFTER, result)
         self._capture_observations(result, input=False)
         return result
+
+    def _validate_recurrent_input(self, tensordict: TensorDictBase) -> None:
+        recurrent = self.descriptor.recurrent
+        if recurrent is None:
+            return
+        for reset_key in recurrent.reset_keys:
+            reset = tensordict.get(reset_key)
+            if not isinstance(reset, torch.Tensor) or reset.dtype is not torch.bool:
+                raise ValueError(f"recurrent reset key {'/'.join(reset_key)} must contain a boolean tensor")
+
+    def _validate_recurrent_output(self, inputs: TensorDictBase, outputs: TensorDictBase) -> None:
+        recurrent = self.descriptor.recurrent
+        if recurrent is None:
+            return
+        for transition in recurrent.transitions:
+            previous = inputs.get(transition.input_key)
+            following = outputs.get(transition.output_key)
+            if not isinstance(previous, torch.Tensor) or not isinstance(following, torch.Tensor):
+                raise ValueError("recurrent state transitions must connect tensor-valued keys")
+            if previous.shape != following.shape or previous.dtype != following.dtype:
+                raise ValueError(
+                    f"recurrent state transition {'/'.join(transition.input_key)} -> "
+                    f"{'/'.join(transition.output_key)} changed shape or dtype"
+                )
 
     def _capture_observations(self, tensordict: TensorDictBase, *, input: bool) -> None:
         if self.observations is None:
@@ -279,6 +416,41 @@ class RuntimeInteractionContext:
 
 def _key_path(key: TensorDictKey) -> tuple[str, ...]:
     return tuple(str(part) for part in key) if isinstance(key, tuple) else (str(key),)
+
+
+def _validate_recurrent_descriptor(descriptor: InteractionDescriptor) -> None:
+    recurrent = descriptor.recurrent
+    assert recurrent is not None
+    input_paths = {key.path for key in descriptor.input_schema.keys}
+    output_paths = {key.path for key in descriptor.output_schema.keys}
+    for transition in recurrent.transitions:
+        if transition.input_key not in input_paths:
+            raise ValueError(f"recurrent input state key {'/'.join(transition.input_key)} is not declared")
+        if transition.output_key not in output_paths:
+            raise ValueError(f"recurrent output state key {'/'.join(transition.output_key)} is not declared")
+    for reset_key in recurrent.reset_keys:
+        if reset_key not in input_paths:
+            raise ValueError(f"recurrent reset key {'/'.join(reset_key)} is not declared")
+    if recurrent.sequence_dimension != descriptor.time_dimension:
+        raise ValueError("recurrent sequence_dimension must match descriptor time_dimension")
+    if recurrent.sequence_dimension is not None and recurrent.sequence_dimension not in descriptor.batch_dimensions:
+        raise ValueError("recurrent sequence_dimension must name a declared batch dimension")
+
+
+def _validate_multi_agent_descriptor(descriptor: InteractionDescriptor) -> None:
+    semantics = descriptor.multi_agent
+    assert semantics is not None
+    if descriptor.agent_dimension is None:
+        raise ValueError("multi-agent interactions require an explicit agent_dimension")
+    if semantics.target.role is not descriptor.role:
+        raise ValueError("semantic target role must match the interaction model role")
+    if semantics.topology is InteractionTopology.CENTRALISED_CRITIC and descriptor.role not in {
+        ModelRole.CRITIC,
+        ModelRole.VALUE,
+    }:
+        raise ValueError("centralised-critic interactions require a critic or value role")
+    if semantics.topology is InteractionTopology.MIXER and descriptor.role is not ModelRole.MIXER:
+        raise ValueError("mixer interactions require the mixer model role")
 
 
 def _restore_training_states(states: tuple[tuple[torch.nn.Module, bool], ...]) -> None:

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -19,7 +19,7 @@ from tensordict.nn import TensorDictModuleBase
 from torchrl.envs.utils import set_exploration_type
 
 from xdrl.interventions import InterventionTiming
-from xdrl.types import ModelRole, TensorDictKey, TensorDictSchema
+from xdrl.types import KeyPresence, KeyRole, ModelRole, TensorDictKey, TensorDictSchema
 
 if TYPE_CHECKING:
     from xdrl.interventions import InterventionController
@@ -343,6 +343,7 @@ class RuntimeInteractionContext:
             self.input_schema.validate_inputs(tensordict)
             if self.interventions is not None:
                 tensordict = self.interventions.apply(self, tensordict, InterventionTiming.INPUT)
+            self._validate_recurrent_input(tensordict)
             self._capture_observations(tensordict, input=True)
             result = invoked_module(tensordict)
         except BaseException as error:
@@ -421,15 +422,21 @@ def _key_path(key: TensorDictKey) -> tuple[str, ...]:
 def _validate_recurrent_descriptor(descriptor: InteractionDescriptor) -> None:
     recurrent = descriptor.recurrent
     assert recurrent is not None
-    input_paths = {key.path for key in descriptor.input_schema.keys}
-    output_paths = {key.path for key in descriptor.output_schema.keys}
+    input_entries = {key.path: key for key in descriptor.input_schema.keys}
+    output_entries = {key.path: key for key in descriptor.output_schema.keys}
     for transition in recurrent.transitions:
-        if transition.input_key not in input_paths:
+        input_entry = input_entries.get(transition.input_key)
+        if input_entry is None:
             raise ValueError(f"recurrent input state key {'/'.join(transition.input_key)} is not declared")
-        if transition.output_key not in output_paths:
+        output_entry = output_entries.get(transition.output_key)
+        if output_entry is None:
             raise ValueError(f"recurrent output state key {'/'.join(transition.output_key)} is not declared")
+        if input_entry.role != KeyRole.STATE.value or input_entry.presence != KeyPresence.REQUIRED.value:
+            raise ValueError(f"recurrent input state key {'/'.join(transition.input_key)} must be required state")
+        if output_entry.role != KeyRole.STATE.value or output_entry.presence != KeyPresence.PRODUCED.value:
+            raise ValueError(f"recurrent output state key {'/'.join(transition.output_key)} must be produced state")
     for reset_key in recurrent.reset_keys:
-        if reset_key not in input_paths:
+        if reset_key not in input_entries:
             raise ValueError(f"recurrent reset key {'/'.join(reset_key)} is not declared")
     if recurrent.sequence_dimension != descriptor.time_dimension:
         raise ValueError("recurrent sequence_dimension must match descriptor time_dimension")

--- a/src/xdrl/observations.py
+++ b/src/xdrl/observations.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from typing import Any
 
@@ -58,19 +58,40 @@ class OverflowPolicy(str, Enum):
     RAISE = "raise"
 
 
+class ReductionKind(str, Enum):
+    """A named tensor reduction supported by observation retention."""
+
+    MEAN = "mean"
+    SUM = "sum"
+    MAX = "max"
+
+
+@dataclass(frozen=True, slots=True)
+class DimensionReduction:
+    """Reduce one explicitly named batch dimension."""
+
+    dimension: str
+    kind: ReductionKind
+
+    def __post_init__(self) -> None:
+        if not self.dimension:
+            raise ValueError("reduction dimension must be non-empty")
+
+
 @dataclass(frozen=True, slots=True)
 class RetentionPolicy:
     """Explicit graph, device, sampling, reduction, and backpressure policy.
 
     ``every_n`` samples observations by monotonically increasing observation
-    order. ``reduction`` applies only across named batch dimensions and emits
-    a record with those dimensions removed.  Payloads are always detached and
-    cloned, so this package never retains a computation graph by accident.
+    order. ``reductions`` applies named policies only to matching batch
+    dimensions and emits a record with those dimensions removed. Payloads are
+    always detached and cloned, so this package never retains a computation
+    graph by accident.
     """
 
     tensor: TensorRetention = TensorRetention.METADATA
     every_n: int = 1
-    reduction: str | None = None
+    reductions: tuple[DimensionReduction, ...] = ()
     max_records: int = 1_024
     overflow: OverflowPolicy = OverflowPolicy.DROP_OLDEST
 
@@ -79,8 +100,13 @@ class RetentionPolicy:
             raise ValueError("every_n must be at least 1")
         if self.max_records < 0:
             raise ValueError("max_records must be non-negative")
-        if self.reduction not in {None, "mean", "sum", "max"}:
-            raise ValueError("reduction must be one of None, 'mean', 'sum', or 'max'")
+        dimensions = tuple(reduction.dimension for reduction in self.reductions)
+        if len(set(dimensions)) != len(dimensions):
+            raise ValueError("each batch dimension can have at most one reduction policy")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the retention and named reduction policies as JSON data."""
+        return asdict(self)
 
 
 @dataclass(frozen=True, slots=True)
@@ -235,12 +261,17 @@ def _retain(
         return None, known_dimensions
     value = tensor.detach()
     retained_dimensions = known_dimensions
-    if policy.reduction is not None and batch_dimensions:
-        dims = tuple(range(len(batch_dimensions)))
+    reductions = () if batch_dimensions is None else policy.reductions
+    for reduction in reductions:
+        if reduction.dimension not in retained_dimensions:
+            raise ValueError(f"reduction dimension {reduction.dimension!r} is not present in {retained_dimensions!r}")
+        dimension = retained_dimensions.index(reduction.dimension)
         value = (
-            torch.amax(value, dim=dims) if policy.reduction == "max" else getattr(value, policy.reduction)(dim=dims)
+            torch.amax(value, dim=dimension)
+            if reduction.kind is ReductionKind.MAX
+            else getattr(value, reduction.kind.value)(dim=dimension)
         )
-        retained_dimensions = ()
+        retained_dimensions = tuple(name for index, name in enumerate(retained_dimensions) if index != dimension)
     if policy.tensor is TensorRetention.CPU:
         value = value.cpu()
     return value.clone(), retained_dimensions

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -162,6 +162,7 @@ def test_agent_and_time_reductions_are_named_serialised_and_opt_in() -> None:
 
     assert record is not None and record.payload is not None
     assert record.payload.shape == (2, 1)
+    assert torch.equal(record.payload, torch.tensor([[22.0], [70.0]]))
     assert record.retained_batch_dimensions == ("env",)
     assert json.loads(json.dumps(policy.to_dict()))["reductions"] == [
         {"dimension": "time", "kind": "mean"},

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -189,6 +189,22 @@ def test_reduction_rejects_an_unnamed_batch_axis() -> None:
         )
 
 
+def test_reduction_policy_rejects_invalid_dimensions_and_limits() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        DimensionReduction("", ReductionKind.MEAN)
+    with pytest.raises(ValueError, match="at most one"):
+        RetentionPolicy(
+            reductions=(
+                DimensionReduction("agent", ReductionKind.MEAN),
+                DimensionReduction("agent", ReductionKind.SUM),
+            )
+        )
+    with pytest.raises(ValueError, match="at least 1"):
+        RetentionPolicy(every_n=0)
+    with pytest.raises(ValueError, match="non-negative"):
+        RetentionPolicy(max_records=-1)
+
+
 def test_composite_schema_parent_captures_nested_tensor_leaves() -> None:
     inputs, outputs = _schemas()
     descriptor = _descriptor(inputs, outputs)

--- a/tests/unit/test_observations.py
+++ b/tests/unit/test_observations.py
@@ -1,14 +1,17 @@
 import json
 
+import pytest
 import torch
 from tensordict import TensorDict
 
 from xdrl.interactions import InteractionDescriptor, InteractionPhase, RuntimeInteractionContext, SchemaSnapshot
 from xdrl.observations import (
+    DimensionReduction,
     HookDirection,
     ObservationKind,
     ObservationTrace,
     OverflowPolicy,
+    ReductionKind,
     RetentionPolicy,
     TensorRetention,
 )
@@ -85,7 +88,13 @@ def test_trace_is_serialisable_and_observation_only_preserves_model_output() -> 
 
 def test_retention_detaches_reduces_and_bounds_records() -> None:
     inputs, outputs = _schemas()
-    trace = ObservationTrace(RetentionPolicy(tensor=TensorRetention.CPU, reduction="mean", max_records=1))
+    trace = ObservationTrace(
+        RetentionPolicy(
+            tensor=TensorRetention.CPU,
+            reductions=(DimensionReduction("env", ReductionKind.MEAN),),
+            max_records=1,
+        )
+    )
     descriptor = _descriptor(inputs, outputs)
     source = torch.tensor([[1.0, 3.0], [5.0, 7.0]], requires_grad=True)
     first = trace.observe_tensor(
@@ -111,7 +120,12 @@ def test_retention_detaches_reduces_and_bounds_records() -> None:
 def test_max_reduction_and_unbatched_hook_tensors_are_handled_explicitly() -> None:
     inputs, outputs = _schemas()
     descriptor = _descriptor(inputs, outputs)
-    trace = ObservationTrace(RetentionPolicy(tensor=TensorRetention.DETACHED, reduction="max"))
+    trace = ObservationTrace(
+        RetentionPolicy(
+            tensor=TensorRetention.DETACHED,
+            reductions=(DimensionReduction("env", ReductionKind.MAX),),
+        )
+    )
     reduced = trace.observe_tensor(
         descriptor,
         torch.tensor([[1.0, 5.0], [4.0, 3.0]]),
@@ -126,6 +140,52 @@ def test_max_reduction_and_unbatched_hook_tensors_are_handled_explicitly() -> No
     assert reduced.retained_batch_dimensions == ()
     assert unbatched is not None and torch.equal(unbatched.payload, torch.tensor([1.0, 5.0]))
     assert unbatched.retained_batch_dimensions == ()
+
+
+def test_agent_and_time_reductions_are_named_serialised_and_opt_in() -> None:
+    policy = RetentionPolicy(
+        tensor=TensorRetention.DETACHED,
+        reductions=(
+            DimensionReduction("time", ReductionKind.MEAN),
+            DimensionReduction("agent", ReductionKind.SUM),
+        ),
+    )
+    trace = ObservationTrace(policy)
+    inputs, outputs = _schemas()
+    record = trace.observe_tensor(
+        _descriptor(inputs, outputs),
+        torch.arange(24, dtype=torch.float).reshape(2, 3, 4, 1),
+        kind=ObservationKind.ACTIVATION,
+        target="shared_encoder",
+        batch_dimensions=("env", "time", "agent"),
+    )
+
+    assert record is not None and record.payload is not None
+    assert record.payload.shape == (2, 1)
+    assert record.retained_batch_dimensions == ("env",)
+    assert json.loads(json.dumps(policy.to_dict()))["reductions"] == [
+        {"dimension": "time", "kind": "mean"},
+        {"dimension": "agent", "kind": "sum"},
+    ]
+
+
+def test_reduction_rejects_an_unnamed_batch_axis() -> None:
+    trace = ObservationTrace(
+        RetentionPolicy(
+            tensor=TensorRetention.DETACHED,
+            reductions=(DimensionReduction("agent", ReductionKind.MEAN),),
+        )
+    )
+    inputs, outputs = _schemas()
+
+    with pytest.raises(ValueError, match="agent.*not present"):
+        trace.observe_tensor(
+            _descriptor(inputs, outputs),
+            torch.zeros(2, 3),
+            kind=ObservationKind.ACTIVATION,
+            target="encoder",
+            batch_dimensions=("env",),
+        )
 
 
 def test_composite_schema_parent_captures_nested_tensor_leaves() -> None:

--- a/tests/unit/test_recurrent_multiagent.py
+++ b/tests/unit/test_recurrent_multiagent.py
@@ -42,6 +42,22 @@ def _descriptor(
     )
 
 
+def _state_schemas(dimensions: tuple[str, ...] = ("env",)) -> tuple[TensorDictSchema, TensorDictSchema]:
+    return (
+        TensorDictSchema(
+            (
+                KeySchema("state", KeyRole.STATE, KeyPresence.REQUIRED),
+                KeySchema("is_init", KeyRole.TERMINATION, KeyPresence.REQUIRED),
+            ),
+            BatchSemantics(dimensions),
+        ),
+        TensorDictSchema(
+            (KeySchema(("next", "state"), KeyRole.STATE, KeyPresence.PRODUCED),),
+            BatchSemantics(dimensions),
+        ),
+    )
+
+
 def test_torchrl_lstm_state_transitions_and_reset_masks_are_validated() -> None:
     inputs = TensorDictSchema(
         (
@@ -130,6 +146,52 @@ def test_recurrent_contract_rejects_bad_masks_and_unsupported_collectors() -> No
             context.invoke(batch.clone().set("is_init", torch.zeros(2, 1)))
 
 
+@pytest.mark.parametrize(
+    ("transitions", "burn_in", "truncated_window", "message"),
+    [
+        ((), 0, None, "at least one"),
+        ((RecurrentStateTransition(("state",), ("next", "state")),), -1, None, "non-negative"),
+        ((RecurrentStateTransition(("state",), ("next", "state")),), 0, 0, "positive"),
+        ((RecurrentStateTransition(("state",), ("next", "state")),), 2, 2, "smaller"),
+    ],
+)
+def test_recurrent_semantics_reject_invalid_windows(
+    transitions: tuple[RecurrentStateTransition, ...],
+    burn_in: int,
+    truncated_window: int | None,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        RecurrentSemantics(transitions, (), burn_in=burn_in, truncated_window=truncated_window)
+
+
+def test_agent_and_multi_agent_semantics_reject_invalid_selectors() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        AgentSelector("")
+    with pytest.raises(ValueError, match="duplicate"):
+        AgentSelector("agents", (1, 1))
+    selector = AgentSelector("agents")
+
+    with pytest.raises(ValueError, match="non-empty"):
+        MultiAgentSemantics(InteractionTopology.INDEPENDENT, "", 2, SemanticTarget(ModelRole.ACTOR, selector))
+    with pytest.raises(ValueError, match="positive"):
+        MultiAgentSemantics(InteractionTopology.INDEPENDENT, "agents", 0, SemanticTarget(ModelRole.ACTOR, selector))
+    with pytest.raises(ValueError, match="must match"):
+        MultiAgentSemantics(
+            InteractionTopology.INDEPENDENT,
+            "agents",
+            2,
+            SemanticTarget(ModelRole.ACTOR, AgentSelector("other")),
+        )
+    with pytest.raises(ValueError, match="outside"):
+        MultiAgentSemantics(
+            InteractionTopology.INDEPENDENT,
+            "agents",
+            2,
+            SemanticTarget(ModelRole.ACTOR, AgentSelector("agents", (2,))),
+        )
+
+
 def test_recurrent_contract_rejects_non_state_transition_keys() -> None:
     inputs = TensorDictSchema(
         (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))
@@ -142,6 +204,73 @@ def test_recurrent_contract_rejects_non_state_transition_keys() -> None:
 
     with pytest.raises(ValueError, match="must be required state"):
         _descriptor(ModelRole.ACTOR, "policy.rnn", inputs, outputs, recurrent=recurrent)
+
+
+@pytest.mark.parametrize(
+    ("transition", "reset_keys", "time_dimension", "sequence_dimension", "message"),
+    [
+        (RecurrentStateTransition(("missing",), ("next", "state")), (), None, None, "input state key.*not declared"),
+        (RecurrentStateTransition(("state",), ("next", "missing")), (), None, None, "output state key.*not declared"),
+        (
+            RecurrentStateTransition(("state",), ("next", "state")),
+            (("missing",),),
+            None,
+            None,
+            "reset key.*not declared",
+        ),
+        (RecurrentStateTransition(("state",), ("next", "state")), (), "other", "time", "must match"),
+        (RecurrentStateTransition(("state",), ("next", "state")), (), "time", "time", "declared batch"),
+    ],
+)
+def test_recurrent_descriptor_rejects_invalid_key_and_time_declarations(
+    transition: RecurrentStateTransition,
+    reset_keys: tuple[tuple[str, ...], ...],
+    time_dimension: str | None,
+    sequence_dimension: str | None,
+    message: str,
+) -> None:
+    inputs, outputs = _state_schemas()
+    recurrent = RecurrentSemantics((transition,), reset_keys, sequence_dimension=sequence_dimension)
+
+    with pytest.raises(ValueError, match=message):
+        _descriptor(
+            ModelRole.ACTOR,
+            "policy.rnn",
+            inputs,
+            outputs,
+            time_dimension=time_dimension,
+            recurrent=recurrent,
+        )
+
+
+@pytest.mark.parametrize(
+    ("topology", "role", "target_role", "agent_dimension", "message"),
+    [
+        (InteractionTopology.INDEPENDENT, ModelRole.ACTOR, ModelRole.ACTOR, None, "agent_dimension"),
+        (InteractionTopology.INDEPENDENT, ModelRole.ACTOR, ModelRole.CRITIC, "agent", "must match"),
+        (InteractionTopology.CENTRALISED_CRITIC, ModelRole.ACTOR, ModelRole.ACTOR, "agent", "critic or value"),
+        (InteractionTopology.MIXER, ModelRole.ACTOR, ModelRole.ACTOR, "agent", "mixer model role"),
+    ],
+)
+def test_multi_agent_descriptor_rejects_invalid_role_and_axis_contracts(
+    topology: InteractionTopology,
+    role: ModelRole,
+    target_role: ModelRole,
+    agent_dimension: str | None,
+    message: str,
+) -> None:
+    schema = TensorDictSchema((), BatchSemantics(("env",)))
+    semantics = MultiAgentSemantics(topology, "agents", 2, SemanticTarget(target_role, AgentSelector("agents")))
+
+    with pytest.raises(ValueError, match=message):
+        _descriptor(
+            role,
+            "policy.module",
+            schema,
+            schema,
+            agent_dimension=agent_dimension,
+            multi_agent=semantics,
+        )
 
 
 def test_replay_sequence_serialises_time_axis_burn_in_and_truncated_window() -> None:

--- a/tests/unit/test_recurrent_multiagent.py
+++ b/tests/unit/test_recurrent_multiagent.py
@@ -1,0 +1,285 @@
+import json
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from torchrl.data import UnboundedContinuous
+from torchrl.modules import LSTMModule, MultiAgentMLP, QMixer
+
+from xdrl.interactions import (
+    AgentSelector,
+    InteractionDescriptor,
+    InteractionPhase,
+    InteractionTopology,
+    MultiAgentSemantics,
+    RecurrentCollectorMode,
+    RecurrentSemantics,
+    RecurrentStateTransition,
+    RuntimeInteractionContext,
+    SchemaSnapshot,
+    SemanticTarget,
+)
+from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
+
+
+def _descriptor(
+    role: ModelRole,
+    module_path: str,
+    inputs: TensorDictSchema,
+    outputs: TensorDictSchema,
+    **kwargs: object,
+) -> InteractionDescriptor:
+    return InteractionDescriptor(
+        identity=f"{role.value}:0",
+        role=role,
+        phase=InteractionPhase.COLLECTION,
+        module_path=module_path,
+        input_schema=SchemaSnapshot.from_schema(inputs),
+        output_schema=SchemaSnapshot.from_schema(outputs),
+        batch_dimensions=inputs.batch.dimensions,
+        **kwargs,
+    )
+
+
+def test_torchrl_lstm_state_transitions_and_reset_masks_are_validated() -> None:
+    inputs = TensorDictSchema(
+        (
+            KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),
+            KeySchema("rs_h", KeyRole.STATE, KeyPresence.REQUIRED),
+            KeySchema("rs_c", KeyRole.STATE, KeyPresence.REQUIRED),
+            KeySchema("is_init", KeyRole.TERMINATION, KeyPresence.REQUIRED),
+        ),
+        BatchSemantics(("env",)),
+    )
+    outputs = TensorDictSchema(
+        (
+            KeySchema("intermediate", KeyRole.FEATURE, KeyPresence.PRODUCED),
+            KeySchema(("next", "rs_h"), KeyRole.STATE, KeyPresence.PRODUCED),
+            KeySchema(("next", "rs_c"), KeyRole.STATE, KeyPresence.PRODUCED),
+        ),
+        BatchSemantics(("env",)),
+    )
+    recurrent = RecurrentSemantics(
+        transitions=(
+            RecurrentStateTransition(("rs_h",), ("next", "rs_h")),
+            RecurrentStateTransition(("rs_c",), ("next", "rs_c")),
+        ),
+        reset_keys=(("is_init",),),
+        collector_mode=RecurrentCollectorMode.SYNC,
+    )
+    descriptor = _descriptor(ModelRole.ACTOR, "policy.lstm", inputs, outputs, recurrent=recurrent)
+    module = LSTMModule(
+        input_size=3,
+        hidden_size=4,
+        in_keys=["observation", "rs_h", "rs_c"],
+        out_keys=["intermediate", ("next", "rs_h"), ("next", "rs_c")],
+    )
+    state = torch.ones(2, 1, 4)
+    batch = TensorDict(
+        {
+            "observation": torch.randn(2, 3),
+            "rs_h": state.clone(),
+            "rs_c": state.clone(),
+            "is_init": torch.tensor([[True], [False]]),
+        },
+        batch_size=[2],
+    )
+    zero_state = batch.clone().set("rs_h", torch.zeros_like(state)).set("rs_c", torch.zeros_like(state))
+    expected_reset = module(zero_state)["next", "rs_h"][0].clone()
+    context = RuntimeInteractionContext(descriptor, module, inputs, outputs, batch)
+
+    result = context(batch.clone())
+
+    assert torch.allclose(result["next", "rs_h"][0], expected_reset)
+    assert result["next", "rs_h"].shape == state.shape
+    json.dumps(descriptor.to_dict())
+
+
+def test_recurrent_contract_rejects_bad_masks_and_unsupported_collectors() -> None:
+    with pytest.raises(NotImplementedError, match="multiprocess"):
+        RecurrentSemantics(
+            transitions=(RecurrentStateTransition(("state",), ("next", "state")),),
+            reset_keys=(("is_init",),),
+            collector_mode=RecurrentCollectorMode.MULTIPROCESS,
+        )
+
+    inputs = TensorDictSchema(
+        (
+            KeySchema("state", KeyRole.STATE, KeyPresence.REQUIRED),
+            KeySchema("is_init", KeyRole.TERMINATION, KeyPresence.REQUIRED),
+        ),
+        BatchSemantics(("env",)),
+    )
+    outputs = TensorDictSchema(
+        (KeySchema(("next", "state"), KeyRole.STATE, KeyPresence.PRODUCED),), BatchSemantics(("env",))
+    )
+    recurrent = RecurrentSemantics(
+        transitions=(RecurrentStateTransition(("state",), ("next", "state")),),
+        reset_keys=(("is_init",),),
+    )
+    descriptor = _descriptor(ModelRole.ACTOR, "policy.rnn", inputs, outputs, recurrent=recurrent)
+    batch = TensorDict(
+        {"state": torch.zeros(2, 1), "is_init": torch.zeros(2, 1)},
+        batch_size=[2],
+    )
+
+    with pytest.raises(ValueError, match="boolean tensor"):
+        RuntimeInteractionContext(descriptor, torch.nn.Identity(), inputs, outputs, batch)
+
+
+def test_replay_sequence_serialises_time_axis_burn_in_and_truncated_window() -> None:
+    inputs = TensorDictSchema(
+        (
+            KeySchema("state", KeyRole.STATE, KeyPresence.REQUIRED),
+            KeySchema("is_init", KeyRole.TERMINATION, KeyPresence.REQUIRED),
+        ),
+        BatchSemantics(("env", "time")),
+    )
+    outputs = TensorDictSchema(
+        (KeySchema(("next", "state"), KeyRole.STATE, KeyPresence.PRODUCED),),
+        BatchSemantics(("env", "time")),
+    )
+    recurrent = RecurrentSemantics(
+        transitions=(RecurrentStateTransition(("state",), ("next", "state")),),
+        reset_keys=(("is_init",),),
+        sequence_dimension="time",
+        burn_in=2,
+        truncated_window=8,
+        collector_mode=RecurrentCollectorMode.REPLAY_SEQUENCE,
+    )
+    descriptor = _descriptor(
+        ModelRole.ACTOR,
+        "policy.rnn",
+        inputs,
+        outputs,
+        time_dimension="time",
+        recurrent=recurrent,
+    )
+
+    encoded = json.loads(json.dumps(descriptor.to_dict()))["recurrent"]
+
+    assert encoded["sequence_dimension"] == "time"
+    assert encoded["burn_in"] == 2
+    assert encoded["truncated_window"] == 8
+
+
+def test_vmas_parameter_sharing_uses_a_semantic_group_target() -> None:
+    n_agents = 3
+    inputs = TensorDictSchema(
+        (
+            KeySchema(
+                ("agents", "observation"),
+                KeyRole.OBSERVATION,
+                KeyPresence.REQUIRED,
+                UnboundedContinuous(shape=(n_agents, 4)),
+            ),
+        ),
+        BatchSemantics(("env",)),
+    )
+    outputs = TensorDictSchema(
+        (
+            KeySchema(
+                ("agents", "action"),
+                KeyRole.ACTION,
+                KeyPresence.PRODUCED,
+                UnboundedContinuous(shape=(n_agents, 2)),
+            ),
+        ),
+        BatchSemantics(("env",)),
+    )
+    semantics = MultiAgentSemantics(
+        topology=InteractionTopology.PARAMETER_SHARED,
+        group="agents",
+        n_agents=n_agents,
+        target=SemanticTarget(ModelRole.ACTOR, AgentSelector("agents")),
+    )
+    descriptor = _descriptor(
+        ModelRole.ACTOR,
+        "policy.module",
+        inputs,
+        outputs,
+        agent_dimension="agent",
+        multi_agent=semantics,
+    )
+    policy = TensorDictModule(
+        MultiAgentMLP(4, 2, n_agents, centralized=False, share_params=True, depth=1, num_cells=8),
+        in_keys=[("agents", "observation")],
+        out_keys=[("agents", "action")],
+    )
+    batch = TensorDict(
+        {("agents", "observation"): torch.randn(5, n_agents, 4)},
+        batch_size=[5],
+    )
+
+    result = RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch)(batch.clone())
+
+    assert result["agents", "action"].shape == (5, n_agents, 2)
+    assert descriptor.multi_agent.target.selector.agents == ()
+    assert descriptor.module_path == "policy.module"
+
+
+@pytest.mark.parametrize(
+    ("topology", "role"),
+    [
+        (InteractionTopology.CENTRALISED_CRITIC, ModelRole.CRITIC),
+        (InteractionTopology.MIXER, ModelRole.MIXER),
+    ],
+)
+def test_centralised_critic_and_mixer_roles_are_serialisable(topology: InteractionTopology, role: ModelRole) -> None:
+    schema = TensorDictSchema((), BatchSemantics(("env",)))
+    semantics = MultiAgentSemantics(topology, "agents", 3, SemanticTarget(role, AgentSelector("agents")))
+    descriptor = _descriptor(
+        role,
+        "loss.mixer" if role is ModelRole.MIXER else "loss.critic",
+        schema,
+        schema,
+        agent_dimension="agent",
+        multi_agent=semantics,
+    )
+
+    assert json.loads(json.dumps(descriptor.to_dict()))["multi_agent"]["topology"] == topology.value
+
+
+def test_qmix_reference_preserves_nested_agent_keys_and_environment_batch() -> None:
+    n_agents = 3
+    inputs = TensorDictSchema(
+        (
+            KeySchema(("agents", "chosen_action_value"), KeyRole.VALUE, KeyPresence.REQUIRED),
+            KeySchema(("agents", "observation"), KeyRole.OBSERVATION, KeyPresence.REQUIRED),
+        ),
+        BatchSemantics(("env",)),
+    )
+    outputs = TensorDictSchema(
+        (KeySchema("chosen_action_value", KeyRole.VALUE, KeyPresence.PRODUCED),), BatchSemantics(("env",))
+    )
+    semantics = MultiAgentSemantics(
+        InteractionTopology.MIXER,
+        "agents",
+        n_agents,
+        SemanticTarget(ModelRole.MIXER, AgentSelector("agents")),
+    )
+    descriptor = _descriptor(
+        ModelRole.MIXER,
+        "loss.mixer_network",
+        inputs,
+        outputs,
+        agent_dimension="agent",
+        multi_agent=semantics,
+    )
+    mixer = TensorDictModule(
+        QMixer(state_shape=(n_agents, 4), mixing_embed_dim=8, n_agents=n_agents, device="cpu"),
+        in_keys=[("agents", "chosen_action_value"), ("agents", "observation")],
+        out_keys=["chosen_action_value"],
+    )
+    batch = TensorDict(
+        {
+            ("agents", "chosen_action_value"): torch.randn(2, n_agents, 1),
+            ("agents", "observation"): torch.randn(2, n_agents, 4),
+        },
+        batch_size=[2],
+    )
+
+    result = RuntimeInteractionContext(descriptor, mixer, inputs, outputs, batch)(batch.clone())
+
+    assert result["chosen_action_value"].shape == (2, 1)

--- a/tests/unit/test_recurrent_multiagent.py
+++ b/tests/unit/test_recurrent_multiagent.py
@@ -120,12 +120,28 @@ def test_recurrent_contract_rejects_bad_masks_and_unsupported_collectors() -> No
     )
     descriptor = _descriptor(ModelRole.ACTOR, "policy.rnn", inputs, outputs, recurrent=recurrent)
     batch = TensorDict(
-        {"state": torch.zeros(2, 1), "is_init": torch.zeros(2, 1)},
+        {"state": torch.zeros(2, 1), "is_init": torch.zeros(2, 1, dtype=torch.bool)},
         batch_size=[2],
     )
+    context = RuntimeInteractionContext(descriptor, torch.nn.Identity(), inputs, outputs, batch)
 
     with pytest.raises(ValueError, match="boolean tensor"):
-        RuntimeInteractionContext(descriptor, torch.nn.Identity(), inputs, outputs, batch)
+        with context:
+            context.invoke(batch.clone().set("is_init", torch.zeros(2, 1)))
+
+
+def test_recurrent_contract_rejects_non_state_transition_keys() -> None:
+    inputs = TensorDictSchema(
+        (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))
+    )
+    outputs = TensorDictSchema((KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),), BatchSemantics(("env",)))
+    recurrent = RecurrentSemantics(
+        transitions=(RecurrentStateTransition(("observation",), ("action",)),),
+        reset_keys=(),
+    )
+
+    with pytest.raises(ValueError, match="must be required state"):
+        _descriptor(ModelRole.ACTOR, "policy.rnn", inputs, outputs, recurrent=recurrent)
 
 
 def test_replay_sequence_serialises_time_axis_burn_in_and_truncated_window() -> None:


### PR DESCRIPTION
## Summary

- add serialisable recurrent state transitions, reset masks, time-window semantics, and explicit supported collector modes
- add semantic multi-agent topology and role/group targeting that separates agents from implementation module paths
- replace implicit all-axis observation reductions with named per-dimension policies
- cover TorchRL LSTM resets, VMAS-style parameter sharing, centralised critic/mixer roles, and QMixer nested keys

## Impact

Recurrent and multi-agent instrumentation can now declare the state, reset, sequence, group, and semantic targeting assumptions that determine what an observation means. Unsupported recurrent worker lifecycles fail explicitly, and agent/time axes remain intact unless a named reduction opts out.

## Validation

- `uv run pytest tests -q` (66 passed)
- `uv run pre-commit run --all-files`
- `uv run --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`

Closes #22