### PR TITLE
Run TDHook planned workflows inside XDRL interactions

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -169,3 +169,10 @@ descriptor are exposed as stable TDHook target paths.
 Lazy modules must be explicitly materialised with ``adapter.materialize()``
 before ``adapter.activate(factory)``. Compiled, distributed, and remote modules
 are rejected instead of being instrumented with ambiguous semantics.
+
+Declared TDHook workflows use ``adapter.run_pipeline(pipeline, artifacts,
+code_revision=...)``. TDHook plans the workflow before execution and remains
+the owner of stage grouping, artifacts, pass counts, and hook cleanup. Every
+planned model call crosses the same live XDRL input/output schema and execution
+mode boundary, and the returned ``TDHookPipelineResult`` links TDHook's stage
+artifacts and plan to the interaction's model and checkpoint provenance.

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -37,7 +37,7 @@ Python            ``>=3.11,<3.14``           required CI matrix
 PyTorch           ``2.11.*``                 compatibility and parity suites
 TensorDict        ``0.12.2``                 schema and parity suites
 TorchRL           ``0.12.0+g5b2bc08b``       compatibility and integration
-TDHook            ``0.1.3.dev0``             adapter conformance suite
+TDHook            ``0.1.3``                  adapter conformance suite
 xdrl              ``0.1.0``                  all required suites
 ================  =========================  ================================
 
@@ -52,9 +52,11 @@ Adapter conformance
 ``tests/behavioural_parity/test_tdhook_adapter.py``. Its conformance contract
 covers TensorDict schema preservation, deterministic observation-only output
 parity, lifecycle cleanup, exception safety, explicit lazy materialisation, and
-target-path resolution. Compiled, distributed, remote, multiprocess, async,
-and distributed-collector paths remain unsupported and are rejected where they
-reach a known boundary.
+target-path resolution. ``tests/integration/test_tdhook_pipeline.py`` owns the
+planned-workflow boundary: TDHook-controlled grouping and pass counts, schema
+validation on every model call, artifact provenance, and failure cleanup.
+Compiled, distributed, remote, multiprocess, async, and distributed-collector
+paths remain unsupported and are rejected where they reach a known boundary.
 
 Test ownership is separated deliberately:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ build-backend = "setuptools.build_meta"
 default-groups = ["dev", "docs", "scripts"]
 
 [tool.uv.sources]
-tdhook = { git = "https://github.com/Xmaster6y/tdhook", rev = "f416f4c3a160e4e7b45f60360f8ce33c9c01682f" }
+tdhook = { git = "https://github.com/Xmaster6y/tdhook", rev = "1a01cd3ea3bc04b9fe60877604d2116b610af108" }
 torchrl = { git = "https://github.com/Xmaster6y/rl", rev = "parity" }
 
 [tool.ruff]

--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -52,7 +52,7 @@ from xdrl.observations import (
     TensorRetention,
 )
 from xdrl.provenance import PROVENANCE_SCHEMA_REVISION, ProvenanceManifest, ProvenanceSchemaError
-from xdrl.tdhook import TDHookInteractionAdapter
+from xdrl.tdhook import TDHookInteractionAdapter, TDHookPipelineResult
 from xdrl.types import ModelRole, TensorDictSchema
 
 try:
@@ -102,6 +102,7 @@ __all__ = [
     "SupportLevel",
     "PairedInterventionResult",
     "TDHookInteractionAdapter",
+    "TDHookPipelineResult",
     "TDHookInterventionFactory",
     "TensorDictSchema",
     "TensorRetention",

--- a/src/xdrl/compatibility.py
+++ b/src/xdrl/compatibility.py
@@ -63,11 +63,11 @@ SUPPORTED_DEPENDENCIES = (
     VersionRequirement("torch", "==2.11.*"),
     VersionRequirement("tensordict", "==0.12.2"),
     VersionRequirement("torchrl", "==0.12.0+g5b2bc08b"),
-    VersionRequirement("tdhook", "==0.1.3.dev0"),
+    VersionRequirement("tdhook", "==0.1.3"),
     VersionRequirement("xdrl", "==0.1.0"),
 )
 SUPPORTED_GIT_REVISIONS = (
-    GitRevisionRequirement("tdhook", "f416f4c3a160e4e7b45f60360f8ce33c9c01682f"),
+    GitRevisionRequirement("tdhook", "1a01cd3ea3bc04b9fe60877604d2116b610af108"),
     GitRevisionRequirement("torchrl", "5b2bc08b034bf228bfa8563629980b939d59b089"),
 )
 

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 from contextlib import ExitStack
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 import torch
 from tensordict import TensorDictBase
@@ -338,6 +338,26 @@ class RuntimeInteractionContext:
         invoked_module = self.module if module is None else module
         if module is not None and module is not self.module and self.descriptor.module_training is not None:
             _set_training_mode(self._stack, invoked_module, self.descriptor.module_training)
+        return self.invoke_callable(tensordict, invoked_module)
+
+    def invoke_callable(
+        self,
+        tensordict: TensorDictBase,
+        operation: Callable[[TensorDictBase], TensorDictBase],
+        *,
+        module: object | None = None,
+    ) -> TensorDictBase:
+        """Invoke one TensorDict operation through this interaction's live contract.
+
+        This is the execution boundary used when another library owns the
+        model wrapper, as TDHook does for planned method calls.  The context
+        must already be active so execution modes and cleanup remain owned by
+        the surrounding interaction.
+        """
+        if self._stack is None:
+            raise RuntimeError("invoke_callable must be called inside the interaction context")
+        if module is not None and module is not self.module and self.descriptor.module_training is not None:
+            _set_training_mode(self._stack, module, self.descriptor.module_training)
         self._record(LifecycleEventType.BEFORE, tensordict)
         try:
             self.input_schema.validate_inputs(tensordict)
@@ -345,7 +365,7 @@ class RuntimeInteractionContext:
                 tensordict = self.interventions.apply(self, tensordict, InterventionTiming.INPUT)
             self._validate_recurrent_input(tensordict)
             self._capture_observations(tensordict, input=True)
-            result = invoked_module(tensordict)
+            result = operation(tensordict)
         except BaseException as error:
             self._record(LifecycleEventType.FAILURE, tensordict, error)
             raise

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -8,10 +8,9 @@ lifecycle handling.
 
 from __future__ import annotations
 
-from copy import copy
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from dataclasses import asdict, dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any, Iterator, Mapping, Sequence
 
 import torch
 from tensordict import TensorDictBase
@@ -176,10 +175,10 @@ class TDHookInteractionAdapter:
         """Execute a TDHook plan while validating every model call through XDRL.
 
         TDHook remains the sole owner of planning, stage grouping, artifacts,
-        pass counts, and hook lifecycle.  XDRL supplies a shallow execution
-        view of the selected module whose every forward call crosses the live
-        interaction contract.  The original direct-factory API remains
-        available through :meth:`activate`.
+        pass counts, and hook lifecycle. XDRL temporarily intercepts the
+        selected module's own forward method so every call crosses the live
+        interaction contract without changing the module identity. The
+        original direct-factory API remains available through :meth:`activate`.
         """
         if self._stack is not None:
             raise RuntimeError("run_pipeline cannot be used while the TDHook adapter is active")
@@ -192,8 +191,7 @@ class TDHookInteractionAdapter:
             raise RuntimeError("selected module has lazy parameters; call materialize() before run_pipeline()")
 
         planned = pipeline.plan(artifacts)
-        with self.interaction:
-            validated_model = _schema_validated_copy(self.selected_module, self.interaction)
+        with self.interaction, _schema_validated_module(self.selected_module, self.interaction) as validated_model:
             result = pipeline.run(
                 validated_model,
                 artifacts,
@@ -261,7 +259,7 @@ def _tdhook_path(path: str) -> str:
 
 
 class _SchemaValidatedForward:
-    """Mixin injected into a shallow module copy used only for one pipeline."""
+    """Mixin temporarily injected into the original module for one pipeline."""
 
     def forward(self, tensordict: TensorDictBase, *args: object, **kwargs: object) -> TensorDictBase:
         if args or kwargs:
@@ -275,22 +273,39 @@ class _SchemaValidatedForward:
         )
 
 
-def _schema_validated_copy(
+@contextmanager
+def _schema_validated_module(
     module: TensorDictModuleBase, interaction: RuntimeInteractionContext
-) -> TensorDictModuleBase:
-    """Preserve the module tree while intercepting its calls for validation."""
-    validated = copy(module)
+) -> Iterator[TensorDictModuleBase]:
+    """Intercept the original module in place and restore it after execution."""
     original_type = type(module)
     validated_type = type(f"_XDRLValidated{original_type.__name__}", (_SchemaValidatedForward, original_type), {})
+    missing = object()
+    previous_interaction = module.__dict__.get("_xdrl_interaction", missing)
+    previous_forward = module.__dict__.get("_xdrl_original_forward", missing)
+    changed_class = False
     try:
-        validated.__class__ = validated_type
+        module.__class__ = validated_type
+        changed_class = True
+        module._xdrl_interaction = interaction
+        module._xdrl_original_forward = original_type.forward
     except TypeError as error:
         raise NotImplementedError(
             f"planned TDHook execution cannot bind module type {original_type.__name__}"
         ) from error
-    validated._xdrl_interaction = interaction
-    validated._xdrl_original_forward = original_type.forward
-    return validated
+    try:
+        yield module
+    finally:
+        if previous_interaction is missing:
+            delattr(module, "_xdrl_interaction")
+        else:
+            module._xdrl_interaction = previous_interaction
+        if previous_forward is missing:
+            delattr(module, "_xdrl_original_forward")
+        else:
+            module._xdrl_original_forward = previous_forward
+        if changed_class:
+            module.__class__ = original_type
 
 
 def _tdhook_method_record(stage: Any, method: Any, plan: ExecutionPlan) -> dict[str, Any]:

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -8,17 +8,20 @@ lifecycle handling.
 
 from __future__ import annotations
 
+from copy import copy
 from contextlib import ExitStack
-from dataclasses import dataclass, field
-from typing import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping, Sequence
 
 import torch
 from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
 from tdhook.contexts import HookingContext, HookingContextFactory
 from tdhook.hooks import resolve_submodule_path
+from tdhook.pipeline import ExecutionPlan, Pipeline, PipelineResult
 
 from xdrl.interactions import RuntimeInteractionContext
+from xdrl.provenance import ProvenanceManifest
 from xdrl.types import KeyPresence, TensorDictKey
 
 
@@ -28,6 +31,27 @@ def _key_path(key: TensorDictKey) -> tuple[str, ...]:
 
 def _module_keys(module: TensorDictModuleBase, attribute: str) -> set[tuple[str, ...]]:
     return {_key_path(key) for key in getattr(module, attribute)}
+
+
+@dataclass(frozen=True, slots=True)
+class TDHookPipelineResult:
+    """A TDHook pipeline result linked to its typed XDRL interaction."""
+
+    pipeline: PipelineResult
+    interaction_provenance: tuple[ProvenanceManifest, ...]
+
+    @property
+    def artifacts(self) -> TensorDictBase:
+        """Return the artifacts produced by TDHook."""
+        return self.pipeline.artifacts
+
+    @property
+    def plan(self) -> ExecutionPlan:
+        """Return the exact TDHook plan used for execution."""
+        plan = self.pipeline.plan
+        if plan is None:
+            raise RuntimeError("TDHook pipeline result does not contain an execution plan")
+        return plan
 
 
 @dataclass(slots=True)
@@ -140,6 +164,57 @@ class TDHookInteractionAdapter:
             raise RuntimeError("invoke must be called inside an active TDHook adapter")
         return self.interaction.invoke(tensordict, module=self._hooked_module)
 
+    def run_pipeline(
+        self,
+        pipeline: Pipeline,
+        artifacts: TensorDictBase,
+        *,
+        code_revision: str,
+        seed: int | None = None,
+        stage_configurations: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> TDHookPipelineResult:
+        """Execute a TDHook plan while validating every model call through XDRL.
+
+        TDHook remains the sole owner of planning, stage grouping, artifacts,
+        pass counts, and hook lifecycle.  XDRL supplies a shallow execution
+        view of the selected module whose every forward call crosses the live
+        interaction contract.  The original direct-factory API remains
+        available through :meth:`activate`.
+        """
+        if self._stack is not None:
+            raise RuntimeError("run_pipeline cannot be used while the TDHook adapter is active")
+        if not isinstance(pipeline, Pipeline):
+            raise TypeError(f"pipeline must be a TDHook Pipeline, got {type(pipeline).__name__}")
+        if not isinstance(artifacts, TensorDictBase):
+            raise TypeError(f"pipeline artifacts must be a TensorDict, got {type(artifacts).__name__}")
+        assert self.selected_module is not None
+        if _has_uninitialized_parameters(self.selected_module):
+            raise RuntimeError("selected module has lazy parameters; call materialize() before run_pipeline()")
+
+        planned = pipeline.plan(artifacts)
+        with self.interaction:
+            validated_model = _schema_validated_copy(self.selected_module, self.interaction)
+            result = pipeline.run(
+                validated_model,
+                artifacts,
+                model_id=self.interaction.descriptor.model_id or self.interaction.descriptor.module_path,
+                seed=seed,
+                stage_configurations=stage_configurations,
+            )
+        if result.plan != planned:
+            raise RuntimeError("TDHook execution plan changed after preflight")
+        manifests = tuple(
+            ProvenanceManifest.capture(
+                self.interaction.descriptor,
+                selected_keys=tuple(_key_path(key) for key in (*self.input_keys, *self.output_keys)),
+                target_paths=self.target_paths,
+                tdhook_method=_tdhook_method_record(stage, method, planned),
+                code_revision=code_revision,
+            )
+            for stage, method in zip(result.stages, result.provenance, strict=True)
+        )
+        return TDHookPipelineResult(result, manifests)
+
     def _validate_selection(self) -> None:
         assert self.selected_module is not None
         model_inputs = _module_keys(self.selected_module, "in_keys")
@@ -183,6 +258,52 @@ def _require_subset(label: str, actual: set[tuple[str, ...]], expected: set[tupl
 
 def _tdhook_path(path: str) -> str:
     return "td_module" if not path else f"td_module.{path}"
+
+
+class _SchemaValidatedForward:
+    """Mixin injected into a shallow module copy used only for one pipeline."""
+
+    def forward(self, tensordict: TensorDictBase, *args: object, **kwargs: object) -> TensorDictBase:
+        if args or kwargs:
+            raise TypeError("planned XDRL interactions require one TensorDict positional argument")
+        interaction: RuntimeInteractionContext = self._xdrl_interaction
+        original_forward = self._xdrl_original_forward
+        return interaction.invoke_callable(
+            tensordict,
+            lambda current: original_forward(self, current),
+            module=self,
+        )
+
+
+def _schema_validated_copy(
+    module: TensorDictModuleBase, interaction: RuntimeInteractionContext
+) -> TensorDictModuleBase:
+    """Preserve the module tree while intercepting its calls for validation."""
+    validated = copy(module)
+    original_type = type(module)
+    validated_type = type(f"_XDRLValidated{original_type.__name__}", (_SchemaValidatedForward, original_type), {})
+    try:
+        validated.__class__ = validated_type
+    except TypeError as error:
+        raise NotImplementedError(
+            f"planned TDHook execution cannot bind module type {original_type.__name__}"
+        ) from error
+    validated._xdrl_interaction = interaction
+    validated._xdrl_original_forward = original_type.forward
+    return validated
+
+
+def _tdhook_method_record(stage: Any, method: Any, plan: ExecutionPlan) -> dict[str, Any]:
+    planned_run = next(run for run in plan.runs if stage.name in run.stages)
+    record = asdict(method)
+    record["provided_keys"] = [_key_path(key) for key in stage.provided_keys]
+    record["planned_run"] = {
+        "stages": list(planned_run.stages),
+        "kind": planned_run.kind,
+        "model_passes": planned_run.model_passes,
+        "coalesced": planned_run.coalesced,
+    }
+    return record
 
 
 def _has_uninitialized_parameters(module: torch.nn.Module) -> bool:

--- a/tests/integration/test_provenance.py
+++ b/tests/integration/test_provenance.py
@@ -34,7 +34,7 @@ def _dependencies() -> dict[str, str]:
         "torch": "2.11.0",
         "tensordict": "0.12.2",
         "torchrl": "0.12.0+g5b2bc08b",
-        "tdhook": "0.1.3.dev0",
+        "tdhook": "0.1.3",
         "xdrl": "0.1.0",
     }
 

--- a/tests/integration/test_tdhook_pipeline.py
+++ b/tests/integration/test_tdhook_pipeline.py
@@ -1,0 +1,184 @@
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from tdhook.contexts import HookingContextFactory
+from tdhook.hooks import MultiHookHandle
+from tdhook.modules import HookedModule
+from tdhook.pipeline import MethodStage, Pipeline, TransformStage
+
+from xdrl.interactions import (
+    InteractionDescriptor,
+    InteractionPhase,
+    LifecycleEventType,
+    RuntimeInteractionContext,
+    SchemaSnapshot,
+)
+from xdrl.tdhook import TDHookInteractionAdapter
+from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
+
+
+INPUT_KEY = ("inputs", "input")
+OUTPUT_KEY = ("outputs", "model")
+
+
+class AddOne(HookingContextFactory):
+    def _hook_module(self, module: HookedModule) -> MultiHookHandle:
+        return module.register_submodule_hook("module", lambda module, args, output: output + 1, direction="fwd")
+
+
+class TimesTwo(HookingContextFactory):
+    def _hook_module(self, module: HookedModule) -> MultiHookHandle:
+        return module.register_submodule_hook("module", lambda module, args, output: output * 2, direction="fwd")
+
+
+class CountingLinear(torch.nn.Linear):
+    def __init__(self) -> None:
+        super().__init__(2, 1, bias=False)
+        self.calls = 0
+        self.training_during_calls: list[bool] = []
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        self.calls += 1
+        self.training_during_calls.append(self.training)
+        return super().forward(value)
+
+
+def _interaction() -> tuple[RuntimeInteractionContext, CountingLinear]:
+    inputs = TensorDictSchema(
+        (KeySchema(INPUT_KEY, KeyRole.OBSERVATION, KeyPresence.REQUIRED),),
+        BatchSemantics(("env",)),
+    )
+    outputs = TensorDictSchema(
+        (KeySchema(OUTPUT_KEY, KeyRole.ACTION, KeyPresence.PRODUCED),),
+        BatchSemantics(("env",)),
+    )
+    layer = CountingLinear()
+    with torch.no_grad():
+        layer.weight.copy_(torch.tensor([[2.0, -1.0]]))
+    policy = TensorDictModule(layer, in_keys=[INPUT_KEY], out_keys=[OUTPUT_KEY])
+    policy.train()
+    batch = TensorDict({"inputs": {"input": torch.ones(3, 2)}}, batch_size=[3])
+    descriptor = InteractionDescriptor(
+        identity="policy:evaluation:planned",
+        role=ModelRole.ACTOR,
+        phase=InteractionPhase.EVALUATION,
+        module_path="policy",
+        input_schema=SchemaSnapshot.from_schema(inputs),
+        output_schema=SchemaSnapshot.from_schema(outputs),
+        batch_dimensions=("env",),
+        model_id="actor-v3",
+        checkpoint_id="sha256:planned",
+        module_training=False,
+    )
+    return RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch), layer
+
+
+def _method(
+    name: str,
+    factory: HookingContextFactory,
+    *,
+    required_keys: tuple[tuple[str, str], ...],
+    provided_keys: tuple[tuple[str, str], ...] = (),
+    coexecution_key: str | None = None,
+) -> MethodStage:
+    return MethodStage(
+        name,
+        factory,
+        required_keys=required_keys,
+        provided_keys=provided_keys,
+        model_in_keys=[INPUT_KEY],
+        model_out_keys=[OUTPUT_KEY],
+        coexecution_key=coexecution_key,
+        device_batch_constraints=["same interaction batch"] if coexecution_key else (),
+    )
+
+
+@pytest.mark.integration
+def test_planned_compatible_stages_share_one_validated_interaction_call() -> None:
+    interaction, layer = _interaction()
+    artifacts = interaction.representative_input.clone()
+    pipeline = Pipeline(
+        [
+            _method("add", AddOne(), required_keys=(INPUT_KEY,), coexecution_key="ordered-hooks-v1"),
+            _method(
+                "multiply",
+                TimesTwo(),
+                required_keys=(INPUT_KEY,),
+                provided_keys=(OUTPUT_KEY,),
+                coexecution_key="ordered-hooks-v1",
+            ),
+        ]
+    )
+
+    result = TDHookInteractionAdapter(interaction).run_pipeline(
+        pipeline, artifacts, code_revision="abc123", seed=7
+    )
+
+    assert result.plan.model_passes == 1
+    assert result.plan.runs[0].coalesced
+    assert layer.calls == 1
+    assert layer.training_during_calls == [False]
+    assert interaction.module.training
+    assert torch.equal(result.artifacts.get(OUTPUT_KEY), torch.full((3, 1), 4.0))
+    assert [event.kind for event in interaction.events] == [LifecycleEventType.BEFORE, LifecycleEventType.AFTER]
+    assert len(result.interaction_provenance) == 2
+    manifest = result.interaction_provenance[0]
+    assert manifest.model_id == "actor-v3"
+    assert manifest.checkpoint_id == "sha256:planned"
+    assert manifest.tdhook_method["planned_run"]["model_passes"] == 1
+    assert manifest.tdhook_method["planned_run"]["coalesced"] is True
+    assert not layer._forward_hooks
+
+
+@pytest.mark.integration
+def test_planned_incompatible_stages_remain_separate_and_report_two_passes() -> None:
+    interaction, layer = _interaction()
+    pipeline = Pipeline(
+        [
+            _method("first", AddOne(), required_keys=(INPUT_KEY,), provided_keys=(OUTPUT_KEY,)),
+            _method("second", TimesTwo(), required_keys=(OUTPUT_KEY,)),
+        ]
+    )
+
+    result = TDHookInteractionAdapter(interaction).run_pipeline(
+        pipeline, interaction.representative_input.clone(), code_revision="abc123"
+    )
+
+    assert [run.stages for run in result.plan.runs] == [("first",), ("second",)]
+    assert result.plan.model_passes == 2
+    assert layer.calls == 2
+    assert [event.kind for event in interaction.events] == [
+        LifecycleEventType.BEFORE,
+        LifecycleEventType.AFTER,
+        LifecycleEventType.BEFORE,
+        LifecycleEventType.AFTER,
+    ]
+    assert not layer._forward_hooks
+
+
+@pytest.mark.integration
+def test_every_planned_call_revalidates_schema_and_restores_hooks_after_failure() -> None:
+    interaction, layer = _interaction()
+    pipeline = Pipeline(
+        [
+            _method("first", AddOne(), required_keys=(INPUT_KEY,), provided_keys=(OUTPUT_KEY,)),
+            TransformStage("drop-input", lambda td: td.del_(INPUT_KEY), required_keys=[OUTPUT_KEY]),
+            _method("second", TimesTwo(), required_keys=(OUTPUT_KEY,)),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="second.*missing required key"):
+        TDHookInteractionAdapter(interaction).run_pipeline(
+            pipeline, interaction.representative_input.clone(), code_revision="abc123"
+        )
+
+    assert layer.calls == 1
+    assert interaction.module.training
+    assert [event.kind for event in interaction.events] == [
+        LifecycleEventType.BEFORE,
+        LifecycleEventType.AFTER,
+        LifecycleEventType.BEFORE,
+        LifecycleEventType.FAILURE,
+    ]
+    assert not layer._forward_hooks

--- a/tests/integration/test_tdhook_pipeline.py
+++ b/tests/integration/test_tdhook_pipeline.py
@@ -111,9 +111,7 @@ def test_planned_compatible_stages_share_one_validated_interaction_call() -> Non
         ]
     )
 
-    result = TDHookInteractionAdapter(interaction).run_pipeline(
-        pipeline, artifacts, code_revision="abc123", seed=7
-    )
+    result = TDHookInteractionAdapter(interaction).run_pipeline(pipeline, artifacts, code_revision="abc123", seed=7)
 
     assert result.plan.model_passes == 1
     assert result.plan.runs[0].coalesced

--- a/tests/integration/test_tdhook_pipeline.py
+++ b/tests/integration/test_tdhook_pipeline.py
@@ -44,7 +44,17 @@ class CountingLinear(torch.nn.Linear):
         return super().forward(value)
 
 
-def _interaction() -> tuple[RuntimeInteractionContext, CountingLinear]:
+class StatefulTensorDictModule(TensorDictModule):
+    def __init__(self, module: torch.nn.Module) -> None:
+        super().__init__(module, in_keys=[INPUT_KEY], out_keys=[OUTPUT_KEY])
+        self.root_calls = 0
+
+    def forward(self, tensordict: TensorDict, **kwargs: object) -> TensorDict:
+        self.root_calls += 1
+        return super().forward(tensordict, **kwargs)
+
+
+def _interaction(*, stateful: bool = False) -> tuple[RuntimeInteractionContext, CountingLinear]:
     inputs = TensorDictSchema(
         (KeySchema(INPUT_KEY, KeyRole.OBSERVATION, KeyPresence.REQUIRED),),
         BatchSemantics(("env",)),
@@ -56,7 +66,11 @@ def _interaction() -> tuple[RuntimeInteractionContext, CountingLinear]:
     layer = CountingLinear()
     with torch.no_grad():
         layer.weight.copy_(torch.tensor([[2.0, -1.0]]))
-    policy = TensorDictModule(layer, in_keys=[INPUT_KEY], out_keys=[OUTPUT_KEY])
+    policy = (
+        StatefulTensorDictModule(layer)
+        if stateful
+        else TensorDictModule(layer, in_keys=[INPUT_KEY], out_keys=[OUTPUT_KEY])
+    )
     policy.train()
     batch = TensorDict({"inputs": {"input": torch.ones(3, 2)}}, batch_size=[3])
     descriptor = InteractionDescriptor(
@@ -180,3 +194,19 @@ def test_every_planned_call_revalidates_schema_and_restores_hooks_after_failure(
         LifecycleEventType.FAILURE,
     ]
     assert not layer._forward_hooks
+
+
+@pytest.mark.integration
+def test_planned_execution_preserves_root_module_state_and_identity() -> None:
+    interaction, _ = _interaction(stateful=True)
+    assert isinstance(interaction.module, StatefulTensorDictModule)
+    pipeline = Pipeline(
+        [_method("predict", HookingContextFactory(), required_keys=(INPUT_KEY,), provided_keys=(OUTPUT_KEY,))]
+    )
+
+    TDHookInteractionAdapter(interaction).run_pipeline(
+        pipeline, interaction.representative_input.clone(), code_revision="abc123"
+    )
+
+    assert type(interaction.module) is StatefulTensorDictModule
+    assert interaction.module.root_calls == 1

--- a/uv.lock
+++ b/uv.lock
@@ -2820,8 +2820,8 @@ wheels = [
 
 [[package]]
 name = "tdhook"
-version = "0.1.3.dev0"
-source = { git = "https://github.com/Xmaster6y/tdhook?rev=f416f4c3a160e4e7b45f60360f8ce33c9c01682f#f416f4c3a160e4e7b45f60360f8ce33c9c01682f" }
+version = "0.1.3"
+source = { git = "https://github.com/Xmaster6y/tdhook?rev=1a01cd3ea3bc04b9fe60877604d2116b610af108#1a01cd3ea3bc04b9fe60877604d2116b610af108" }
 dependencies = [
     { name = "tensordict" },
     { name = "torch" },
@@ -3432,7 +3432,7 @@ scripts = [
 [package.metadata]
 requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
-    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?rev=f416f4c3a160e4e7b45f60360f8ce33c9c01682f" },
+    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?rev=1a01cd3ea3bc04b9fe60877604d2116b610af108" },
     { name = "torchrl", git = "https://github.com/Xmaster6y/rl?rev=parity" },
 ]
 


### PR DESCRIPTION
## Summary

- add `TDHookInteractionAdapter.run_pipeline()` so TDHook plans and executes declared workflows while every model call crosses XDRL schema and lifecycle validation
- return TDHook artifacts and the exact execution plan alongside XDRL provenance linked to the interaction, model, and checkpoint
- preserve TDHook grouping, pass counts, hook cleanup, execution modes, and the existing direct single-factory adapter API
- advance the pinned TDHook revision to the tested planning-capable main commit

## Why

The existing adapter prepared raw hook factories directly, so XDRL had no integration boundary for TDHook's execution planner. Independently combining factories would duplicate TDHook scheduling decisions and could silently change whether stages share or split model calls.

## Impact

Callers can now execute a declared TDHook `Pipeline` inside a typed XDRL interaction without losing either library's ownership boundaries. Compatible stages share calls only when TDHook plans them together; incompatible stages stay separate, and every actual model call is checked against the interaction schemas.

## Validation

- `just tests` — 105 passed, 79.06% coverage
- `uv run pre-commit run --all-files`
- `just docs` — warnings treated as errors

Closes #34