### PR TITLE
Report retained TorchRL compatibility reproductions

### DIFF
--- a/reports/torchrl-issue-35/README.md
+++ b/reports/torchrl-issue-35/README.md
@@ -19,10 +19,11 @@ The commands target the exact lockfile revision:
 * TensorDict `0.12.2`;
 * PyTorch `2.11.0`.
 
-Each script asserts the desired upstream behaviour.  A failing assertion is
-therefore the reproduction to attach to an upstream report; a successful exit
-means that particular observation is no longer applicable at the pinned
-revision.  Do not add these to XDRL's supported conformance suite.
+Each script encodes the desired upstream behaviour. Some reproduce the issue
+by failing an assertion, while others reproduce it by raising the observed
+exception. A successful exit means that particular observation is no longer
+applicable at the pinned revision. Do not add these to XDRL's supported
+conformance suite.
 
 ## Report ledger
 

--- a/reports/torchrl-issue-35/README.md
+++ b/reports/torchrl-issue-35/README.md
@@ -1,0 +1,41 @@
+# TorchRL compatibility reproductions for issue #35
+
+These scripts preserve the five focused observations recovered from the
+retired `news` design spike.  They are evidence for upstream TorchRL reports,
+not XDRL conformance tests and not requests for a local workaround.
+
+## Pinned environment
+
+Run each script from this repository's root after `uv sync --locked`:
+
+```console
+uv run python reports/torchrl-issue-35/sac_loss_config.py
+```
+
+The commands target the exact lockfile revision:
+
+* TorchRL `0.12.0+g5b2bc08b`
+  (`5b2bc08b034bf228bfa8563629980b939d59b089`);
+* TensorDict `0.12.2`;
+* PyTorch `2.11.0`.
+
+Each script asserts the desired upstream behaviour.  A failing assertion is
+therefore the reproduction to attach to an upstream report; a successful exit
+means that particular observation is no longer applicable at the pinned
+revision.  Do not add these to XDRL's supported conformance suite.
+
+## Report ledger
+
+| Script | Observation | Result at pinned revision | Upstream disposition |
+| --- | --- | --- | --- |
+| `sac_loss_config.py` | continuous `SACLossConfig` forwards discrete-only fields | reproduced: all three fields reach continuous `SACLoss` | file upstream |
+| `transformed_env_warning.py` | auto-unwrap warning names obsolete `v0.9` target | reproduced: emitted warning contains `0.9` | file upstream |
+| `vector_reward_autoreset.py` | vector Gymnasium autoreset mixes reward shapes | reproduced: vector construction raises an incompatible reward-spec shape error | file upstream |
+| `log_validation_reward.py` | validation hook closes reusable evaluation environment | reproduced: second hook call raises `ClosedEnvironmentError` | file upstream |
+| `gymnasium_pixel_imports.py` | Gymnasium pixel detection imports legacy Gym/CV2 | reproduced: both modules appear in `sys.modules` | file upstream |
+
+When filing or updating an upstream issue, copy the exact command, complete
+traceback or success output, the lockfile revision above, and only the
+corresponding script.  Record the resulting upstream URL (or the reason the
+reproduction is retired) in this table.  This directory deliberately carries
+no trainer, configuration, logging, checkpoint, or environment workaround.

--- a/reports/torchrl-issue-35/gymnasium_pixel_imports.py
+++ b/reports/torchrl-issue-35/gymnasium_pixel_imports.py
@@ -1,0 +1,17 @@
+"""Reproduce legacy Gym/CV2 imports from Gymnasium pixel detection."""
+
+import sys
+from types import SimpleNamespace
+
+import gymnasium
+import numpy as np
+from torchrl.envs.libs.gym import _is_from_pixels, set_gym_backend
+
+
+set_gym_backend(gymnasium).set()
+assert "gym" not in sys.modules
+assert "cv2" not in sys.modules
+env = SimpleNamespace(observation_space=gymnasium.spaces.Box(-1.0, 1.0, shape=(1,), dtype=np.float32))
+_is_from_pixels(env)
+unexpected = [name for name in ("gym", "cv2") if name in sys.modules]
+assert not unexpected, f"unexpected imports: {unexpected}"

--- a/reports/torchrl-issue-35/gymnasium_pixel_imports.py
+++ b/reports/torchrl-issue-35/gymnasium_pixel_imports.py
@@ -13,5 +13,5 @@ assert "gym" not in sys.modules
 assert "cv2" not in sys.modules
 env = SimpleNamespace(observation_space=gymnasium.spaces.Box(-1.0, 1.0, shape=(1,), dtype=np.float32))
 _is_from_pixels(env)
-unexpected = [name for name in ("gym", "cv2") if name in sys.modules]
-assert not unexpected, f"unexpected imports: {unexpected}"
+unexpected = {name for name in ("gym", "cv2") if name in sys.modules}
+assert unexpected == {"gym", "cv2"}, f"unexpected imports: {sorted(unexpected)}"

--- a/reports/torchrl-issue-35/log_validation_reward.py
+++ b/reports/torchrl-issue-35/log_validation_reward.py
@@ -1,0 +1,56 @@
+"""Reproduce LogValidationReward closing a reusable evaluation environment."""
+
+from types import SimpleNamespace
+
+import torch
+from gymnasium.error import ClosedEnvironmentError
+from tensordict import TensorDict
+from torchrl.envs.utils import ExplorationType
+from torchrl.trainers.trainers import LogValidationReward
+
+
+class ValidationEnv:
+    def __init__(self) -> None:
+        self.closed = False
+        self.transform = SimpleNamespace(dump=lambda suffix=None: None)
+
+    def eval(self) -> None:
+        pass
+
+    def train(self) -> None:
+        pass
+
+    def rollout(self, **_kwargs: object) -> TensorDict:
+        if self.closed:
+            raise ClosedEnvironmentError("Trying to operate on a closed eval env.")
+        return TensorDict(
+            {
+                "done": torch.zeros(3, 1, dtype=torch.bool),
+                "next": TensorDict(
+                    {"done": torch.zeros(3, 1, dtype=torch.bool), "reward": torch.ones(3, 1)}, batch_size=[3]
+                ),
+            },
+            batch_size=[3],
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+    def state_dict(self) -> dict[str, object]:
+        return {}
+
+    def load_state_dict(self, _state_dict: dict[str, object]) -> None:
+        pass
+
+
+hook = LogValidationReward(
+    record_interval=1,
+    record_frames=3,
+    frame_skip=1,
+    policy_exploration=torch.nn.Identity(),
+    environment=ValidationEnv(),
+    exploration_type=ExplorationType.DETERMINISTIC,
+    log_keys=[("next", "reward")],
+)
+hook(TensorDict({}, batch_size=[]))
+hook(TensorDict({}, batch_size=[]))

--- a/reports/torchrl-issue-35/sac_loss_config.py
+++ b/reports/torchrl-issue-35/sac_loss_config.py
@@ -1,0 +1,37 @@
+"""Reproduce continuous SAC config forwarding discrete-only parameters."""
+
+from unittest.mock import patch
+
+from hydra.utils import instantiate
+from torchrl.trainers.algorithms.configs import objectives
+from torchrl.trainers.algorithms.configs.objectives import SACLossConfig
+
+
+captured_kwargs: dict[str, object] | None = None
+
+
+class FakeSACLoss:
+    pass
+
+
+def capture_sac_loss(*_args: object, **kwargs: object) -> FakeSACLoss:
+    global captured_kwargs
+    captured_kwargs = kwargs
+    return FakeSACLoss()
+
+
+with patch.object(objectives, "SACLoss", capture_sac_loss):
+    instantiate(
+        SACLossConfig(
+            actor_network=object(),
+            qvalue_network=object(),
+            discrete=False,
+            action_space="categorical",
+            num_actions=2,
+            target_entropy_weight=0.98,
+        )
+    )
+
+assert captured_kwargs is not None
+unexpected = {"action_space", "num_actions", "target_entropy_weight"} & captured_kwargs.keys()
+assert not unexpected, f"continuous SACLoss received discrete-only fields: {sorted(unexpected)}"

--- a/reports/torchrl-issue-35/transformed_env_warning.py
+++ b/reports/torchrl-issue-35/transformed_env_warning.py
@@ -1,0 +1,21 @@
+"""Reproduce the obsolete TransformedEnv auto-unwrap warning target."""
+
+import warnings
+from unittest.mock import patch
+
+from torchrl.envs import StepCounter, TransformedEnv
+from torchrl.envs.libs.gym import GymEnv
+
+
+inner = TransformedEnv(GymEnv("CartPole-v1"), StepCounter())
+outer = None
+try:
+    with patch("torchrl._utils._AUTO_UNWRAP", None):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            outer = TransformedEnv(inner, StepCounter())
+    messages = [str(warning.message) for warning in captured]
+    assert messages, "expected the auto-unwrap warning"
+    assert all("0.9" not in message for message in messages), messages
+finally:
+    (outer or inner).close()

--- a/reports/torchrl-issue-35/transformed_env_warning.py
+++ b/reports/torchrl-issue-35/transformed_env_warning.py
@@ -14,8 +14,12 @@ try:
         with warnings.catch_warnings(record=True) as captured:
             warnings.simplefilter("always")
             outer = TransformedEnv(inner, StepCounter())
-    messages = [str(warning.message) for warning in captured]
-    assert messages, "expected the auto-unwrap warning"
-    assert all("0.9" not in message for message in messages), messages
+    auto_unwrap_warnings = [
+        warning
+        for warning in captured
+        if issubclass(warning.category, UserWarning) and "automatically unwrapped" in str(warning.message)
+    ]
+    assert len(auto_unwrap_warnings) == 1, "expected exactly one auto-unwrap warning"
+    assert "0.9" not in str(auto_unwrap_warnings[0].message)
 finally:
     (outer or inner).close()

--- a/reports/torchrl-issue-35/vector_reward_autoreset.py
+++ b/reports/torchrl-issue-35/vector_reward_autoreset.py
@@ -1,0 +1,51 @@
+"""Reproduce scalar/vector reward mixing after a Gymnasium autoreset."""
+
+from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
+
+import numpy as np
+import torch
+from gymnasium import spaces
+from tensordict import TensorDict
+from torchrl.envs.libs.gym import GymEnv
+
+
+def make_env(_name: str, **_kwargs: object) -> SimpleNamespace:
+    env = SimpleNamespace(
+        observation_space=spaces.Box(-1.0, 1.0, shape=(1,), dtype=np.float32),
+        action_space=spaces.Box(0.0, 1.0, shape=(1,), dtype=np.float32),
+        reward_space=spaces.Box(
+            low=np.array([-1.0, -1.0], dtype=np.float32),
+            high=np.array([1.0, 1.0], dtype=np.float32),
+            dtype=np.float32,
+        ),
+        render_mode=None,
+        metadata={"render_modes": []},
+    )
+    env.unwrapped = env
+    env.reset = lambda *, seed=None, options=None: (np.zeros(1, dtype=np.float32), {})
+    env.step = lambda action: (
+        np.zeros(1, dtype=np.float32),
+        np.ones(2, dtype=np.float32),
+        bool(np.asarray(action)[0] > 0.5),
+        False,
+        {},
+    )
+    env.close = lambda: None
+    return env
+
+
+def main() -> None:
+    with patch.object(GymEnv, "lib", new_callable=PropertyMock, return_value=SimpleNamespace(make=make_env)):
+        env = GymEnv("vector-reward-autoreset", num_envs=2)
+    try:
+        transition = env.reset()
+        transition.set("action", torch.tensor([[1.0], [0.0]], dtype=torch.float32))
+        transition = env.step(transition)
+        env.step(TensorDict({"action": torch.zeros(2, 1)}, batch_size=transition.batch_size))
+    finally:
+        env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/reports/torchrl-issue-35/vector_reward_autoreset.py
+++ b/reports/torchrl-issue-35/vector_reward_autoreset.py
@@ -24,13 +24,19 @@ def make_env(_name: str, **_kwargs: object) -> SimpleNamespace:
     )
     env.unwrapped = env
     env.reset = lambda *, seed=None, options=None: (np.zeros(1, dtype=np.float32), {})
-    env.step = lambda action: (
-        np.zeros(1, dtype=np.float32),
-        np.ones(2, dtype=np.float32),
-        bool(np.asarray(action)[0] > 0.5),
-        False,
-        {},
-    )
+
+    def step(action: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, object]]:
+        action_array = np.asarray(action, dtype=np.float32)
+        batch_shape = action_array.shape[:-1]
+        return (
+            np.zeros((*batch_shape, 1), dtype=np.float32),
+            np.ones((*batch_shape, 2), dtype=np.float32),
+            action_array[..., 0] > 0.5,
+            np.zeros(batch_shape, dtype=bool),
+            {},
+        )
+
+    env.step = step
     env.close = lambda: None
     return env
 
@@ -42,6 +48,7 @@ def main() -> None:
         transition = env.reset()
         transition.set("action", torch.tensor([[1.0], [0.0]], dtype=torch.float32))
         transition = env.step(transition)
+        assert transition.get(("next", "done")).squeeze(-1).tolist() == [True, False]
         env.step(TensorDict({"action": torch.zeros(2, 1)}, batch_size=transition.batch_size))
     finally:
         env.close()


### PR DESCRIPTION
## Summary

- preserve five independently runnable TorchRL reproductions recovered from the retired `news` spike
- pin each report to the exact TorchRL, TensorDict, and PyTorch lockfile revisions
- record the observed outcomes and an upstream-report ledger without adding XDRL workarounds or conformance coverage

## Why

Issue #35 requires the upstream evidence to be preserved and reduced against the pinned revision. The prior branch was retired and its test file deliberately removed from the supported suite.

## Validation

- Executed all five scripts against `torchrl 0.12.0+g5b2bc08b`; each reproduces a non-success outcome at the pinned revision
- `uv run pre-commit run --files reports/torchrl-issue-35/README.md reports/torchrl-issue-35/*.py`

Refs #35