### PR TITLE
Automate development dependency snapshot refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Install dependencies
       run: |
         uv sync --locked
+    - name: Check dependency snapshot drift
+      run: |
+        just check-dependency-snapshot
     - name: Run checks
       run: |
         just checks

--- a/.github/workflows/dependency-refresh.yml
+++ b/.github/workflows/dependency-refresh.yml
@@ -1,0 +1,40 @@
+name: Dependency snapshot refresh
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install just
+        uses: extractions/setup-just@v3
+        with:
+          just-version: 1.41.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Resolve and report the proposed snapshot
+        run: just refresh-dependencies
+      - name: Preserve the reviewable proposal
+        if: always()
+        run: git diff --binary > dependency-refresh.patch
+      - name: Upload the proposed snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-refresh-${{ github.run_id }}-python-${{ matrix.python-version }}
+          path: dependency-refresh.patch
+          if-no-files-found: error

--- a/.github/workflows/dependency-refresh.yml
+++ b/.github/workflows/dependency-refresh.yml
@@ -17,23 +17,30 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
         with:
           just-version: 1.41.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Resolve and report the proposed snapshot
         run: just refresh-dependencies
       - name: Preserve the reviewable proposal
+        id: proposal
         if: always()
-        run: git diff --binary > dependency-refresh.patch
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff --binary > dependency-refresh.patch
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Upload the proposed snapshot
-        if: always()
-        uses: actions/upload-artifact@v4
+        if: ${{ always() && steps.proposal.outputs.changed == 'true' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dependency-refresh-${{ github.run_id }}-python-${{ matrix.python-version }}
           path: dependency-refresh.patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,36 @@ To run the tests (using `pytest`):
 just tests
 ```
 
+## Refreshing development dependencies
+
+`uv.lock` is the exact compatibility snapshot; a branch name or a successful
+installation is not support evidence. Run the single refresh workflow from a
+clean branch:
+
+```bash
+just refresh-dependencies
+```
+
+The command resolves the configured TDHook and TorchRL development branches,
+refreshes TDHook, TensorDict, PyTorch, and TorchRL, synchronises
+`SUPPORTED_DEPENDENCIES`, `SUPPORTED_GIT_REVISIONS`, and the documented matrix,
+prints an old/new version and Git-revision table, then runs formatting, unit,
+upstream-compatibility, integration, behavioural-parity, coverage, and
+documentation gates. Keep a failed proposal intact for diagnosis; do not
+replace a failing revision or widen the generated declarations without passing
+the gates.
+
+CI runs `just check-dependency-snapshot` and fails when `uv.lock`, the runtime
+declarations, or this documentation disagree. The scheduled/manual
+`Dependency snapshot refresh` action uploads the complete patch even when a gate
+fails, so the proposal remains auditable rather than becoming a support claim.
+
+PyTorch currently resolves from its stable index for the supported Python
+3.11--3.13 CI matrix. If a platform needs the PyTorch nightly index, declare it
+with a mutually exclusive environment marker in `tool.uv.sources`, document the
+same local-development marker here, and verify every supported Python/platform
+fork in the generated universal lock before accepting the refresh.
+
 ## Branches
 
 Make a branch before making a pull request to `develop`.

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,22 @@ install:
 checks:
 	uv run pre-commit run --all-files
 
+check-dependency-snapshot:
+	uv run python scripts/dependency_snapshot.py check
+
+sync-dependency-snapshot:
+	uv run python scripts/dependency_snapshot.py sync
+
+refresh-dependencies:
+	uv run python scripts/dependency_snapshot.py refresh
+	just dependency-gates
+
+dependency-gates:
+	just check-dependency-snapshot
+	just checks
+	just tests
+	just docs
+
 test-assets:
 	@echo "No test assets to resolve"
 

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -30,16 +30,20 @@ Tested version matrix
 The lockfile is the reproducible source of exact revisions. The public runtime
 contract accepts only the following tested versions:
 
-================  =========================  ================================
-Component         Tested requirement         Evidence
-================  =========================  ================================
-Python            ``>=3.11,<3.14``           required CI matrix
-PyTorch           ``2.11.*``                 compatibility and parity suites
-TensorDict        ``0.12.2``                 schema and parity suites
-TorchRL           ``0.12.0+g5b2bc08b``       compatibility and integration
-TDHook            ``0.1.3``                  adapter conformance suite
-xdrl              ``0.1.0``                  all required suites
-================  =========================  ================================
+.. dependency-snapshot: start
+
+==========  ======================  ===============================
+Component   Tested requirement      Evidence
+==========  ======================  ===============================
+Python      ``>=3.11,<3.14``        required CI matrix
+PyTorch     ``==2.11.*``            compatibility and parity suites
+TensorDict  ``==0.12.2``            schema and parity suites
+TorchRL     ``==0.12.0+g5b2bc08b``  compatibility and integration
+TDHook      ``==0.1.3``             adapter conformance suite
+xdrl        ``==0.1.0``             all required suites
+==========  ======================  ===============================
+
+.. dependency-snapshot: end
 
 The current TorchRL and TDHook sources are Git revisions recorded in
 ``uv.lock``. A newly installable upstream revision remains experimental until

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ build-backend = "setuptools.build_meta"
 default-groups = ["dev", "docs", "scripts"]
 
 [tool.uv.sources]
-tdhook = { git = "https://github.com/Xmaster6y/tdhook", rev = "1a01cd3ea3bc04b9fe60877604d2116b610af108" }
+tdhook = { git = "https://github.com/Xmaster6y/tdhook", branch = "main" }
 torchrl = { git = "https://github.com/Xmaster6y/rl", rev = "parity" }
 
 [tool.ruff]

--- a/scripts/dependency_snapshot.py
+++ b/scripts/dependency_snapshot.py
@@ -1,0 +1,304 @@
+"""Refresh and validate XDRL's test-backed dependency snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tomllib
+from typing import NamedTuple
+
+from packaging.markers import Marker, UndefinedEnvironmentName
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCKFILE = ROOT / "uv.lock"
+PYPROJECT = ROOT / "pyproject.toml"
+COMPATIBILITY = ROOT / "src" / "xdrl" / "compatibility.py"
+COMPATIBILITY_START = "# dependency-snapshot: start"
+COMPATIBILITY_END = "# dependency-snapshot: end"
+DOCUMENTATION = ROOT / "docs" / "source" / "compatibility.rst"
+DOCUMENTATION_START = ".. dependency-snapshot: start"
+DOCUMENTATION_END = ".. dependency-snapshot: end"
+
+TRACKED_DEPENDENCIES = ("torch", "tensordict", "torchrl", "tdhook", "xdrl")
+REFRESH_PACKAGES = ("torch", "tensordict", "torchrl", "tdhook")
+EVIDENCE = {
+    "torch": "compatibility and parity suites",
+    "tensordict": "schema and parity suites",
+    "torchrl": "compatibility and integration",
+    "tdhook": "adapter conformance suite",
+    "xdrl": "all required suites",
+}
+
+
+class SnapshotError(RuntimeError):
+    """The lockfile cannot produce one unambiguous compatibility snapshot."""
+
+
+class Dependency(NamedTuple):
+    """One exact distribution selected by the universal lockfile."""
+
+    name: str
+    version: str
+    commit: str | None
+    marker: str | None = None
+
+
+def read_snapshot(lockfile: Path = LOCKFILE) -> tuple[Dependency, ...]:
+    """Read exact versions and Git revisions from ``uv.lock``."""
+    payload = tomllib.loads(lockfile.read_text())
+    packages = payload.get("package", [])
+    snapshot: list[Dependency] = []
+    for name in TRACKED_DEPENDENCIES:
+        matches = [package for package in packages if package.get("name") == name]
+        if not matches:
+            raise SnapshotError(f"expected at least one {name!r} package in {lockfile}")
+        for package in matches:
+            version = package.get("version")
+            if not isinstance(version, str) or not version:
+                raise SnapshotError(f"package {name!r} has no exact version in {lockfile}")
+            source = package.get("source", {})
+            git = source.get("git") if isinstance(source, dict) else None
+            commit = _git_commit(git, name) if isinstance(git, str) else None
+            marker = _resolution_marker(package.get("resolution-markers"), name)
+            snapshot.append(Dependency(name, version, commit, marker))
+    return tuple(snapshot)
+
+
+def compatibility_block(snapshot: tuple[Dependency, ...]) -> str:
+    """Render the generated public compatibility declarations."""
+    requirements: list[str] = []
+    for dependency in snapshot:
+        if dependency.marker is None:
+            requirements.append(f'    VersionRequirement("{dependency.name}", "{_specifier(dependency)}"),')
+        else:
+            requirements.extend(
+                (
+                    "    VersionRequirement(",
+                    f'        "{dependency.name}",',
+                    f'        "{_specifier(dependency)}",',
+                    f"        marker={dependency.marker!r},",
+                    "    ),",
+                )
+            )
+    revisions = [
+        f'    GitRevisionRequirement("{dependency.name}", "{dependency.commit}"),'
+        for dependency in snapshot
+        if dependency.commit is not None
+    ]
+    return "\n".join(
+        [
+            COMPATIBILITY_START,
+            "SUPPORTED_DEPENDENCIES = (",
+            *requirements,
+            ")",
+            "SUPPORTED_GIT_REVISIONS = (",
+            *revisions,
+            ")",
+            COMPATIBILITY_END,
+        ]
+    )
+
+
+def documentation_block(snapshot: tuple[Dependency, ...]) -> str:
+    """Render the generated compatibility matrix rows."""
+    rows = [("Python", "``>=3.11,<3.14``", "required CI matrix")]
+    display_names = {
+        "torch": "PyTorch",
+        "tensordict": "TensorDict",
+        "torchrl": "TorchRL",
+        "tdhook": "TDHook",
+        "xdrl": "xdrl",
+    }
+    rows.extend(
+        (
+            display_names[item.name],
+            f"``{_specifier(item)}``",
+            EVIDENCE[item.name] + (f"; ``{item.marker}``" if item.marker is not None else ""),
+        )
+        for item in snapshot
+    )
+    widths = [max(len(row[column]) for row in rows) for column in range(3)]
+    separator = "  ".join("=" * width for width in widths)
+    body = [DOCUMENTATION_START, "", separator]
+    body.append(
+        "  ".join(
+            value.ljust(widths[index])
+            for index, value in enumerate(("Component", "Tested requirement", "Evidence"))
+        ).rstrip()
+    )
+    body.append(separator)
+    for component, requirement, evidence in rows:
+        values = (component, requirement, evidence)
+        body.append("  ".join(value.ljust(widths[index]) for index, value in enumerate(values)).rstrip())
+    body.extend((separator, "", DOCUMENTATION_END))
+    return "\n".join(body)
+
+
+def synchronize(snapshot: tuple[Dependency, ...], *, check: bool) -> list[Path]:
+    """Update or check all generated views of the lockfile snapshot."""
+    replacements = {
+        COMPATIBILITY: (COMPATIBILITY_START, COMPATIBILITY_END, compatibility_block(snapshot)),
+        DOCUMENTATION: (DOCUMENTATION_START, DOCUMENTATION_END, documentation_block(snapshot)),
+    }
+    changed: list[Path] = []
+    for path, (start, end, block) in replacements.items():
+        original = path.read_text()
+        updated = _replace_block(original, start, end, block, path)
+        if updated != original:
+            changed.append(path)
+            if not check:
+                path.write_text(updated)
+    return changed
+
+
+def report(old: tuple[Dependency, ...], new: tuple[Dependency, ...]) -> str:
+    """Return a review-oriented old/new snapshot table."""
+    old_by_name = _group_snapshot(old)
+    new_by_name = _group_snapshot(new)
+    lines = ["| Dependency | Old version | New version | Old revision | New revision |", "| --- | --- | --- | --- | --- |"]
+    for name in TRACKED_DEPENDENCIES:
+        previous = old_by_name[name]
+        current = new_by_name[name]
+        lines.append(
+            f"| {name} | {_display_versions(previous)} | {_display_versions(current)} | "
+            f"{_display_revisions(previous)} | {_display_revisions(current)} |"
+        )
+    return "\n".join(lines)
+
+
+def refresh() -> int:
+    """Resolve configured sources, synchronize declarations, and report the delta."""
+    validate_pytorch_sources()
+    old = read_snapshot()
+    command = ["uv", "lock"]
+    for package in REFRESH_PACKAGES:
+        command.extend(("--upgrade-package", package))
+    subprocess.run(command, cwd=ROOT, check=True)
+    new = read_snapshot()
+    synchronize(new, check=False)
+    summary = report(old, new)
+    print(summary)
+    if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary_path).open("a") as stream:
+            stream.write("## Dependency snapshot\n\n")
+            stream.write(summary)
+            stream.write("\n")
+    return 0
+
+
+def check() -> int:
+    """Fail when the lock, declarations, or documented matrix disagree."""
+    validate_pytorch_sources()
+    subprocess.run(("uv", "lock", "--check"), cwd=ROOT, check=True)
+    changed = synchronize(read_snapshot(), check=True)
+    if changed:
+        paths = ", ".join(str(path.relative_to(ROOT)) for path in changed)
+        print(f"dependency snapshot drift detected in: {paths}", file=sys.stderr)
+        print("run `just sync-dependency-snapshot` after reviewing uv.lock", file=sys.stderr)
+        return 1
+    print("dependency snapshot is consistent")
+    return 0
+
+
+def validate_pytorch_sources(pyproject: Path = PYPROJECT) -> None:
+    """Prove optional stable/nightly markers cover the supported matrix once."""
+    payload = tomllib.loads(pyproject.read_text())
+    uv = payload.get("tool", {}).get("uv", {})
+    sources = uv.get("sources", {})
+    torch_sources = sources.get("torch")
+    if torch_sources is None or isinstance(torch_sources, dict):
+        return
+    if not isinstance(torch_sources, list) or not torch_sources:
+        raise SnapshotError("tool.uv.sources.torch must be a source or a non-empty marker list")
+    indexes = {index.get("name") for index in uv.get("index", []) if isinstance(index, dict)}
+    for source in torch_sources:
+        if not isinstance(source, dict) or not isinstance(source.get("marker"), str):
+            raise SnapshotError("every platform-specific PyTorch source must declare a marker")
+        if source.get("index") not in indexes:
+            raise SnapshotError(f"PyTorch source refers to undeclared index {source.get('index')!r}")
+    for python_version in ("3.11", "3.12", "3.13"):
+        for sys_platform in ("darwin", "linux", "win32"):
+            environment = {"python_version": python_version, "sys_platform": sys_platform}
+            try:
+                matches = [source for source in torch_sources if Marker(source["marker"]).evaluate(environment)]
+            except UndefinedEnvironmentName as error:
+                raise SnapshotError(f"PyTorch source marker cannot be evaluated: {error}") from error
+            if len(matches) != 1:
+                raise SnapshotError(
+                    "PyTorch source markers must select exactly one index for "
+                    f"Python {python_version} on {sys_platform}; selected {len(matches)}"
+                )
+
+
+def _git_commit(source: str, name: str) -> str:
+    _, separator, commit = source.rpartition("#")
+    if not separator or len(commit) != 40 or any(character not in "0123456789abcdef" for character in commit.lower()):
+        raise SnapshotError(f"Git package {name!r} has no immutable 40-character commit in uv.lock")
+    return commit
+
+
+def _resolution_marker(value: object, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, list) or not value or not all(isinstance(marker, str) for marker in value):
+        raise SnapshotError(f"package {name!r} has invalid resolution markers in uv.lock")
+    return " or ".join(f"({marker})" for marker in value)
+
+
+def _specifier(dependency: Dependency) -> str:
+    if dependency.name == "torch":
+        release = dependency.version.split("+", 1)[0].split(".")
+        if len(release) < 2:
+            raise SnapshotError(f"cannot derive a minor PyTorch boundary from {dependency.version!r}")
+        return f"=={release[0]}.{release[1]}.*"
+    return f"=={dependency.version}"
+
+
+def _replace_block(text: str, start: str, end: str, replacement: str, path: Path) -> str:
+    start_index = text.find(start)
+    end_index = text.find(end, start_index + len(start))
+    if start_index < 0 or end_index < 0 or text.find(start, start_index + 1) >= 0 or text.find(end, end_index + 1) >= 0:
+        raise SnapshotError(f"expected exactly one generated snapshot block in {path}")
+    end_index += len(end)
+    return text[:start_index] + replacement + text[end_index:]
+
+
+def _short_revision(commit: str | None) -> str:
+    return commit[:12] if commit is not None else "registry"
+
+
+def _group_snapshot(snapshot: tuple[Dependency, ...]) -> dict[str, tuple[Dependency, ...]]:
+    return {name: tuple(item for item in snapshot if item.name == name) for name in TRACKED_DEPENDENCIES}
+
+
+def _display_versions(dependencies: tuple[Dependency, ...]) -> str:
+    return "<br>".join(
+        dependency.version + (f" ({dependency.marker})" if dependency.marker is not None else "")
+        for dependency in dependencies
+    )
+
+
+def _display_revisions(dependencies: tuple[Dependency, ...]) -> str:
+    return "<br>".join(_short_revision(dependency.commit) for dependency in dependencies)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("check", "refresh", "sync"))
+    arguments = parser.parse_args(argv)
+    if arguments.action == "check":
+        return check()
+    if arguments.action == "refresh":
+        return refresh()
+    changed = synchronize(read_snapshot(), check=False)
+    for path in changed:
+        print(f"updated {path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dependency_snapshot.py
+++ b/scripts/dependency_snapshot.py
@@ -126,8 +126,7 @@ def documentation_block(snapshot: tuple[Dependency, ...]) -> str:
     body = [DOCUMENTATION_START, "", separator]
     body.append(
         "  ".join(
-            value.ljust(widths[index])
-            for index, value in enumerate(("Component", "Tested requirement", "Evidence"))
+            value.ljust(widths[index]) for index, value in enumerate(("Component", "Tested requirement", "Evidence"))
         ).rstrip()
     )
     body.append(separator)
@@ -159,7 +158,10 @@ def report(old: tuple[Dependency, ...], new: tuple[Dependency, ...]) -> str:
     """Return a review-oriented old/new snapshot table."""
     old_by_name = _group_snapshot(old)
     new_by_name = _group_snapshot(new)
-    lines = ["| Dependency | Old version | New version | Old revision | New revision |", "| --- | --- | --- | --- | --- |"]
+    lines = [
+        "| Dependency | Old version | New version | Old revision | New revision |",
+        "| --- | --- | --- | --- | --- |",
+    ]
     for name in TRACKED_DEPENDENCIES:
         previous = old_by_name[name]
         current = new_by_name[name]
@@ -261,7 +263,12 @@ def _specifier(dependency: Dependency) -> str:
 def _replace_block(text: str, start: str, end: str, replacement: str, path: Path) -> str:
     start_index = text.find(start)
     end_index = text.find(end, start_index + len(start))
-    if start_index < 0 or end_index < 0 or text.find(start, start_index + 1) >= 0 or text.find(end, end_index + 1) >= 0:
+    if (
+        start_index < 0
+        or end_index < 0
+        or text.find(start, start_index + 1) >= 0
+        or text.find(end, end_index + 1) >= 0
+    ):
         raise SnapshotError(f"expected exactly one generated snapshot block in {path}")
     end_index += len(end)
     return text[:start_index] + replacement + text[end_index:]

--- a/scripts/dependency_snapshot.py
+++ b/scripts/dependency_snapshot.py
@@ -174,6 +174,7 @@ def report(old: tuple[Dependency, ...], new: tuple[Dependency, ...]) -> str:
 
 def refresh() -> int:
     """Resolve configured sources, synchronize declarations, and report the delta."""
+    validate_refresh_sources()
     validate_pytorch_sources()
     old = read_snapshot()
     command = ["uv", "lock"]
@@ -194,6 +195,7 @@ def refresh() -> int:
 
 def check() -> int:
     """Fail when the lock, declarations, or documented matrix disagree."""
+    validate_refresh_sources()
     validate_pytorch_sources()
     subprocess.run(("uv", "lock", "--check"), cwd=ROOT, check=True)
     changed = synchronize(read_snapshot(), check=True)
@@ -204,6 +206,21 @@ def check() -> int:
         return 1
     print("dependency snapshot is consistent")
     return 0
+
+
+def validate_refresh_sources(pyproject: Path = PYPROJECT) -> None:
+    """Reject Git source constraints that cannot advance during a refresh."""
+    payload = tomllib.loads(pyproject.read_text())
+    sources = payload.get("tool", {}).get("uv", {}).get("sources", {})
+    for package in REFRESH_PACKAGES:
+        source = sources.get(package)
+        if not isinstance(source, dict) or "git" not in source:
+            continue
+        revision = source.get("rev")
+        if isinstance(revision, str) and _is_commit(revision):
+            raise SnapshotError(
+                f"refresh-managed Git source {package!r} is pinned to an immutable commit; track a branch instead"
+            )
 
 
 def validate_pytorch_sources(pyproject: Path = PYPROJECT) -> None:
@@ -238,9 +255,13 @@ def validate_pytorch_sources(pyproject: Path = PYPROJECT) -> None:
 
 def _git_commit(source: str, name: str) -> str:
     _, separator, commit = source.rpartition("#")
-    if not separator or len(commit) != 40 or any(character not in "0123456789abcdef" for character in commit.lower()):
+    if not separator or not _is_commit(commit):
         raise SnapshotError(f"Git package {name!r} has no immutable 40-character commit in uv.lock")
     return commit
+
+
+def _is_commit(value: str) -> bool:
+    return len(value) == 40 and all(character in "0123456789abcdef" for character in value.lower())
 
 
 def _resolution_marker(value: object, name: str) -> str | None:

--- a/scripts/dependency_snapshot.py
+++ b/scripts/dependency_snapshot.py
@@ -241,7 +241,7 @@ def validate_pytorch_sources(pyproject: Path = PYPROJECT) -> None:
             raise SnapshotError(f"PyTorch source refers to undeclared index {source.get('index')!r}")
     for python_version in ("3.11", "3.12", "3.13"):
         for sys_platform in ("darwin", "linux", "win32"):
-            environment = {"python_version": python_version, "sys_platform": sys_platform}
+            environment = _marker_environment(python_version, sys_platform)
             try:
                 matches = [source for source in torch_sources if Marker(source["marker"]).evaluate(environment)]
             except UndefinedEnvironmentName as error:
@@ -251,6 +251,29 @@ def validate_pytorch_sources(pyproject: Path = PYPROJECT) -> None:
                     "PyTorch source markers must select exactly one index for "
                     f"Python {python_version} on {sys_platform}; selected {len(matches)}"
                 )
+
+
+def _marker_environment(python_version: str, sys_platform: str) -> dict[str, str]:
+    """Return a deterministic marker environment for one supported CI leg."""
+    python_full_version = f"{python_version}.0"
+    os_name, platform_system = {
+        "darwin": ("posix", "Darwin"),
+        "linux": ("posix", "Linux"),
+        "win32": ("nt", "Windows"),
+    }[sys_platform]
+    return {
+        "implementation_name": "cpython",
+        "implementation_version": python_full_version,
+        "os_name": os_name,
+        "platform_machine": "x86_64",
+        "platform_python_implementation": "CPython",
+        "platform_release": "",
+        "platform_system": platform_system,
+        "platform_version": "",
+        "python_full_version": python_full_version,
+        "python_version": python_version,
+        "sys_platform": sys_platform,
+    }
 
 
 def _git_commit(source: str, name: str) -> str:

--- a/src/xdrl/compatibility.py
+++ b/src/xdrl/compatibility.py
@@ -75,7 +75,7 @@ SUPPORTED_DEPENDENCIES = (
 )
 SUPPORTED_GIT_REVISIONS = (
     GitRevisionRequirement("torchrl", "5b2bc08b034bf228bfa8563629980b939d59b089"),
-    GitRevisionRequirement("tdhook", "1a01cd3ea3bc04b9fe60877604d2116b610af108"),
+    GitRevisionRequirement("tdhook", "dbb5e4ca37d5d6e2057bf22559746aad844c160d"),
 )
 # dependency-snapshot: end
 

--- a/src/xdrl/compatibility.py
+++ b/src/xdrl/compatibility.py
@@ -166,6 +166,7 @@ def installed_dependency_versions() -> dict[str, str]:
     result = {
         requirement.distribution: _installed_version(requirement.distribution)
         for requirement in SUPPORTED_DEPENDENCIES
+        if requirement.applies()
     }
     result["python"] = ".".join(str(part) for part in sys.version_info[:3])
     return result

--- a/src/xdrl/compatibility.py
+++ b/src/xdrl/compatibility.py
@@ -13,6 +13,7 @@ from importlib.metadata import PackageNotFoundError, distribution, version
 import json
 from typing import Any
 
+from packaging.markers import Marker
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
@@ -48,6 +49,11 @@ class VersionRequirement:
     distribution: str
     specifier: str
     support: SupportLevel = SupportLevel.SUPPORTED
+    marker: str | None = None
+
+    def applies(self) -> bool:
+        """Return whether this conditional requirement targets this runtime."""
+        return self.marker is None or Marker(self.marker).evaluate()
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,6 +65,7 @@ class GitRevisionRequirement:
 
 
 SUPPORTED_PYTHON = VersionRequirement("python", ">=3.11,<3.14")
+# dependency-snapshot: start
 SUPPORTED_DEPENDENCIES = (
     VersionRequirement("torch", "==2.11.*"),
     VersionRequirement("tensordict", "==0.12.2"),
@@ -67,9 +74,10 @@ SUPPORTED_DEPENDENCIES = (
     VersionRequirement("xdrl", "==0.1.0"),
 )
 SUPPORTED_GIT_REVISIONS = (
-    GitRevisionRequirement("tdhook", "1a01cd3ea3bc04b9fe60877604d2116b610af108"),
     GitRevisionRequirement("torchrl", "5b2bc08b034bf228bfa8563629980b939d59b089"),
+    GitRevisionRequirement("tdhook", "1a01cd3ea3bc04b9fe60877604d2116b610af108"),
 )
+# dependency-snapshot: end
 
 
 class ConformanceCheck(str, Enum):
@@ -169,7 +177,8 @@ def validate_runtime_compatibility() -> dict[str, str]:
     _validate_version(SUPPORTED_PYTHON, python_version)
     versions = installed_dependency_versions()
     for requirement in SUPPORTED_DEPENDENCIES:
-        _validate_version(requirement, versions[requirement.distribution])
+        if requirement.applies():
+            _validate_version(requirement, versions[requirement.distribution])
     revisions = installed_dependency_revisions()
     for requirement in SUPPORTED_GIT_REVISIONS:
         if revisions[requirement.distribution] != requirement.commit:

--- a/tests/unit/test_compatibility.py
+++ b/tests/unit/test_compatibility.py
@@ -1,5 +1,6 @@
 import pytest
 
+import xdrl.compatibility as compatibility
 from xdrl.compatibility import (
     ADAPTER_CONFORMANCE,
     SUPPORT_DEFINITIONS,
@@ -31,3 +32,23 @@ def test_version_failures_name_the_failed_boundary() -> None:
         _validate_version(VersionRequirement("example", ">=2"), "1.0")
 
     assert error.value.boundary == "version:example"
+
+
+def test_installed_versions_skip_non_applicable_requirements(monkeypatch: pytest.MonkeyPatch) -> None:
+    requirements = (
+        VersionRequirement("present", "==1"),
+        VersionRequirement("missing", "==1", marker="python_version < '0'"),
+    )
+    requested: list[str] = []
+    monkeypatch.setattr(compatibility, "SUPPORTED_DEPENDENCIES", requirements)
+    monkeypatch.setattr(
+        compatibility,
+        "_installed_version",
+        lambda distribution: requested.append(distribution) or "1.0",
+    )
+
+    versions = compatibility.installed_dependency_versions()
+
+    assert requested == ["present"]
+    assert versions["present"] == "1.0"
+    assert "missing" not in versions

--- a/tests/unit/test_dependency_snapshot.py
+++ b/tests/unit/test_dependency_snapshot.py
@@ -10,6 +10,7 @@ from scripts.dependency_snapshot import (
     documentation_block,
     read_snapshot,
     report,
+    validate_refresh_sources,
     validate_pytorch_sources,
 )
 
@@ -146,3 +147,29 @@ url = "https://pypi.org/simple"
 
     with pytest.raises(SnapshotError, match="select exactly one index"):
         validate_pytorch_sources(pyproject)
+
+
+def test_refresh_sources_accept_a_movable_git_branch(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.uv.sources]
+tdhook = { git = "https://example.invalid/tdhook", branch = "main" }
+torchrl = { git = "https://example.invalid/rl", rev = "parity" }
+"""
+    )
+
+    validate_refresh_sources(pyproject)
+
+
+def test_refresh_sources_reject_an_immutable_git_revision(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        f"""
+[tool.uv.sources]
+tdhook = {{ git = "https://example.invalid/tdhook", rev = "{"a" * 40}" }}
+"""
+    )
+
+    with pytest.raises(SnapshotError, match="pinned to an immutable commit"):
+        validate_refresh_sources(pyproject)

--- a/tests/unit/test_dependency_snapshot.py
+++ b/tests/unit/test_dependency_snapshot.py
@@ -149,6 +149,21 @@ url = "https://pypi.org/simple"
         validate_pytorch_sources(pyproject)
 
 
+def test_pytorch_markers_use_the_synthetic_full_python_and_platform_versions(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.uv.sources]
+torch = [{ index = "stable", marker = "python_full_version in '3.11.0 3.12.0 3.13.0' and ((sys_platform == 'darwin' and platform_system == 'Darwin') or (sys_platform == 'linux' and platform_system == 'Linux') or (sys_platform == 'win32' and platform_system == 'Windows'))" }]
+[[tool.uv.index]]
+name = "stable"
+url = "https://pypi.org/simple"
+"""
+    )
+
+    validate_pytorch_sources(pyproject)
+
+
 def test_refresh_sources_accept_a_movable_git_branch(tmp_path: Path) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(

--- a/tests/unit/test_dependency_snapshot.py
+++ b/tests/unit/test_dependency_snapshot.py
@@ -24,7 +24,11 @@ def _write_lock(path: Path, *, tdhook_commit: str = "a" * 40) -> None:
     ]
     blocks = ["version = 1", "revision = 3"]
     for name, version, commit in packages:
-        source = f'{{ git = "https://example.invalid/{name}?branch=main#{commit}" }}' if commit else '{ registry = "https://pypi.org/simple" }'
+        source = (
+            f'{{ git = "https://example.invalid/{name}?branch=main#{commit}" }}'
+            if commit
+            else '{ registry = "https://pypi.org/simple" }'
+        )
         blocks.append(f'[[package]]\nname = "{name}"\nversion = "{version}"\nsource = {source}')
     path.write_text("\n\n".join(blocks) + "\n")
 
@@ -33,12 +37,12 @@ def _append_conditional_torch(path: Path) -> None:
     text = path.read_text().replace(
         'name = "torch"\nversion = "2.11.0"\nsource = { registry = "https://pypi.org/simple" }',
         'name = "torch"\nversion = "2.11.0"\nsource = { registry = "https://pypi.org/simple" }\n'
-        'resolution-markers = ["python_version == \'3.12\'"]',
+        "resolution-markers = [\"python_version == '3.12'\"]",
     )
     text += (
         '\n[[package]]\nname = "torch"\nversion = "2.12.0.dev1+cpu"\n'
         'source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }\n'
-        'resolution-markers = ["python_version != \'3.12\'"]\n'
+        "resolution-markers = [\"python_version != '3.12'\"]\n"
     )
     path.write_text(text)
 

--- a/tests/unit/test_dependency_snapshot.py
+++ b/tests/unit/test_dependency_snapshot.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+import tomllib
+
+import pytest
+
+from scripts.dependency_snapshot import (
+    Dependency,
+    SnapshotError,
+    compatibility_block,
+    documentation_block,
+    read_snapshot,
+    report,
+    validate_pytorch_sources,
+)
+
+
+def _write_lock(path: Path, *, tdhook_commit: str = "a" * 40) -> None:
+    packages = [
+        ("torch", "2.11.0", None),
+        ("tensordict", "0.12.2", None),
+        ("torchrl", "0.12.0+g12345678", "b" * 40),
+        ("tdhook", "0.1.3", tdhook_commit),
+        ("xdrl", "0.1.0", None),
+    ]
+    blocks = ["version = 1", "revision = 3"]
+    for name, version, commit in packages:
+        source = f'{{ git = "https://example.invalid/{name}?branch=main#{commit}" }}' if commit else '{ registry = "https://pypi.org/simple" }'
+        blocks.append(f'[[package]]\nname = "{name}"\nversion = "{version}"\nsource = {source}')
+    path.write_text("\n\n".join(blocks) + "\n")
+
+
+def _append_conditional_torch(path: Path) -> None:
+    text = path.read_text().replace(
+        'name = "torch"\nversion = "2.11.0"\nsource = { registry = "https://pypi.org/simple" }',
+        'name = "torch"\nversion = "2.11.0"\nsource = { registry = "https://pypi.org/simple" }\n'
+        'resolution-markers = ["python_version == \'3.12\'"]',
+    )
+    text += (
+        '\n[[package]]\nname = "torch"\nversion = "2.12.0.dev1+cpu"\n'
+        'source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }\n'
+        'resolution-markers = ["python_version != \'3.12\'"]\n'
+    )
+    path.write_text(text)
+
+
+def test_read_snapshot_extracts_exact_versions_and_git_commits(tmp_path: Path) -> None:
+    lockfile = tmp_path / "uv.lock"
+    _write_lock(lockfile)
+
+    snapshot = read_snapshot(lockfile)
+
+    assert snapshot[0] == Dependency("torch", "2.11.0", None)
+    assert snapshot[2].commit == "b" * 40
+    assert snapshot[3].commit == "a" * 40
+
+
+def test_read_snapshot_rejects_a_non_immutable_git_source(tmp_path: Path) -> None:
+    lockfile = tmp_path / "uv.lock"
+    _write_lock(lockfile, tdhook_commit="main")
+
+    with pytest.raises(SnapshotError, match="immutable 40-character commit"):
+        read_snapshot(lockfile)
+
+
+def test_read_snapshot_preserves_conditional_stable_and_nightly_versions(tmp_path: Path) -> None:
+    lockfile = tmp_path / "uv.lock"
+    _write_lock(lockfile)
+    _append_conditional_torch(lockfile)
+
+    torch = [item for item in read_snapshot(lockfile) if item.name == "torch"]
+
+    assert [item.version for item in torch] == ["2.11.0", "2.12.0.dev1+cpu"]
+    assert torch[0].marker == "(python_version == '3.12')"
+    assert torch[1].marker == "(python_version != '3.12')"
+
+
+def test_generated_views_share_the_same_snapshot() -> None:
+    snapshot = (
+        Dependency("torch", "2.11.0", None),
+        Dependency("tensordict", "0.12.2", None),
+        Dependency("torchrl", "0.12.0+g12345678", "b" * 40),
+        Dependency("tdhook", "0.1.3", "a" * 40),
+        Dependency("xdrl", "0.1.0", None),
+    )
+
+    declarations = compatibility_block(snapshot)
+    documentation = documentation_block(snapshot)
+
+    assert 'VersionRequirement("torch", "==2.11.*")' in declarations
+    assert 'GitRevisionRequirement("torchrl", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")' in declarations
+    assert "``==0.12.0+g12345678``" in documentation
+
+
+def test_report_makes_registry_and_revision_changes_explicit() -> None:
+    old = (Dependency("torch", "2.11.0", None), Dependency("torchrl", "0.12.0", "a" * 40))
+    new = (Dependency("torch", "2.12.0", None), Dependency("torchrl", "0.13.0", "b" * 40))
+
+    output = report(old, new)
+
+    assert "| torch | 2.11.0 | 2.12.0 | registry | registry |" in output
+    assert "| torchrl | 0.12.0 | 0.13.0 | aaaaaaaaaaaa | bbbbbbbbbbbb |" in output
+
+
+def test_fixture_lock_is_valid_toml(tmp_path: Path) -> None:
+    lockfile = tmp_path / "uv.lock"
+    _write_lock(lockfile)
+    assert len(tomllib.loads(lockfile.read_text())["package"]) == 5
+
+
+def test_pytorch_stable_and_nightly_markers_cover_the_supported_matrix(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.uv.sources]
+torch = [
+    { index = "stable", marker = "sys_platform != 'darwin' or python_version == '3.12'" },
+    { index = "nightly", marker = "sys_platform == 'darwin' and python_version != '3.12'" },
+]
+[[tool.uv.index]]
+name = "stable"
+url = "https://pypi.org/simple"
+[[tool.uv.index]]
+name = "nightly"
+url = "https://download.pytorch.org/whl/nightly/cpu"
+"""
+    )
+
+    validate_pytorch_sources(pyproject)
+
+
+def test_pytorch_markers_reject_an_uncovered_platform(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[tool.uv.sources]
+torch = [{ index = "stable", marker = "sys_platform == 'linux'" }]
+[[tool.uv.index]]
+name = "stable"
+url = "https://pypi.org/simple"
+"""
+    )
+
+    with pytest.raises(SnapshotError, match="select exactly one index"):
+        validate_pytorch_sources(pyproject)

--- a/uv.lock
+++ b/uv.lock
@@ -2821,7 +2821,7 @@ wheels = [
 [[package]]
 name = "tdhook"
 version = "0.1.3"
-source = { git = "https://github.com/Xmaster6y/tdhook?rev=1a01cd3ea3bc04b9fe60877604d2116b610af108#1a01cd3ea3bc04b9fe60877604d2116b610af108" }
+source = { git = "https://github.com/Xmaster6y/tdhook?branch=main#dbb5e4ca37d5d6e2057bf22559746aad844c160d" }
 dependencies = [
     { name = "tensordict" },
     { name = "torch" },
@@ -3432,7 +3432,7 @@ scripts = [
 [package.metadata]
 requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
-    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?rev=1a01cd3ea3bc04b9fe60877604d2116b610af108" },
+    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?branch=main" },
     { name = "torchrl", git = "https://github.com/Xmaster6y/rl?rev=parity" },
 ]
 


### PR DESCRIPTION
## What does this PR do?

- adds one deterministic `just refresh-dependencies` workflow for TDHook, TensorDict, PyTorch, and TorchRL
- derives runtime compatibility declarations and the documented matrix from exact `uv.lock` versions and Git commits
- fails CI when the lockfile, declarations, docs, or platform-specific PyTorch source markers drift
- reports old/new versions and revisions and preserves scheduled refresh proposals as artifacts, including failed gates
- runs refresh proposals across Python 3.11, 3.12, and 3.13 with formatting, tests, coverage, and docs gates

## Validation

- `just tests` — 114 passed, 79.09% coverage
- `just docs` — passed with warnings as errors
- `uv run pre-commit run --all-files` — passed
- `just check-dependency-snapshot` — passed

## Linked Issues

- Closes #37