### PR TITLE
Publish versioned XDRL library skill

### DIFF
--- a/skills/xdrl-library/SKILL.md
+++ b/skills/xdrl-library/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: xdrl-library
+description: Build, review, or explain typed XDRL integrations for TorchRL models with TensorDict schemas, TDHook observation or intervention, recurrent and multi-agent semantics, provenance, and compatibility evidence. Use when work involves the xdrl Python package, XDRL interaction contexts, TDHook adapters or planned workflows, or deciding whether an RL observability concern belongs in XDRL, TorchRL, TensorDict, or TDHook.
+---
+
+# XDRL library
+
+Use XDRL as the typed boundary around an existing TorchRL model call. Keep data and execution in TensorDict/TorchRL, keep generic model-internal methods in TDHook, and use XDRL for interaction semantics, validation, lifecycle restoration, and provenance.
+
+## Select the matching API reference
+
+Check `xdrl.__version__` before writing code. For `0.1.x`, read [references/xdrl-0.1.md](references/xdrl-0.1.md) completely and use only the public `xdrl` namespace shown there. For another version, stop and consult that version's released documentation; do not guess across versions.
+
+Run `xdrl.validate_runtime_compatibility()` before describing a runtime as supported. A successful install or import proves resolution only, not API compatibility, behavioural parity, or conformance.
+
+## Preserve ownership
+
+- Leave environments, collectors, replay, loss modules, optimisation, tensor specs, nested keys, and exploration behavior in TorchRL/TensorDict.
+- Leave activation capture, attribution, probing, patching, steering, hook registration, workflow planning, artifacts, and pass counts in TDHook.
+- Use XDRL for model roles, schemas, interaction phases, execution-state restoration, observation/intervention records, recurrent and multi-agent meaning, compatibility boundaries, and provenance.
+
+Do not introduce an XDRL trainer, data container, tensor-spec hierarchy, or duplicate TDHook method.
+
+## Build an interaction
+
+1. Declare input and output `TensorDictSchema` objects with semantic key roles, presence, native nested keys, TorchRL specs when needed, and named batch dimensions.
+2. Snapshot those schemas into an `InteractionDescriptor`. Record a stable interaction identity, model role, phase, module path, model/checkpoint identity, and exact execution modes.
+3. Wrap the existing TensorDict-compatible module in `RuntimeInteractionContext`. Use the one-shot call for local synchronous execution, or keep the context open when hooks must survive through backward.
+4. Attach an `ObservationTrace` for bounded metadata or opt-in tensor retention. Observation alone must preserve output behavior.
+5. Make every intervention explicit about target, timing, scope, and replacement/transform. Use `run_paired` for matched baseline/intervention mechanics; do not turn mechanical differences into causal claims.
+6. Bind raw TDHook factories with `TDHookInteractionAdapter.activate`. Use `run_pipeline` for a TDHook `Pipeline`; never regroup stages or reinterpret TDHook's planned pass count.
+7. Retain `ProvenanceManifest` records with the model/checkpoint, descriptor, selected keys, resolved target paths, method configuration, dependency versions, and code revision.
+
+## Treat advanced semantics explicitly
+
+- Declare recurrent state as required input and produced next-state keys. Name reset masks and sequence dimensions. Only direct, synchronous, and replay-sequence lifecycles are validated.
+- Target multi-agent work by semantic group, agent selection, model role, and topology. Never use a shared module path as an agent identity.
+- Fail closed for compiled, remote, distributed, multiprocessing, async-collector, and worker-copied execution unless the selected version's conformance contract explicitly supports it.
+
+## Report evidence precisely
+
+Separate these statements:
+
+- package installation/import succeeded;
+- `validate_runtime_compatibility()` accepted the dependency boundary;
+- a named unit, integration, upstream-compatibility, or behavioural-parity suite passed;
+- the requested execution mode is supported, experimental, or unsupported;
+- an observed behavioral or scientific conclusion is justified by experiment evidence.
+
+Name the exact conformance suite behind any support claim. Preserve failures and unsupported-mode errors rather than weakening the declared boundary.

--- a/skills/xdrl-library/agents/openai.yaml
+++ b/skills/xdrl-library/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "XDRL Library"
+  short_description: "Build typed, evidence-backed XDRL workflows"
+  default_prompt: "Use $xdrl-library to build a typed TorchRL interaction with XDRL."

--- a/skills/xdrl-library/references/xdrl-0.1.md
+++ b/skills/xdrl-library/references/xdrl-0.1.md
@@ -1,0 +1,228 @@
+# XDRL 0.1 public API
+
+Use this reference for `xdrl==0.1.*`. All XDRL symbols in the examples come from the public package namespace.
+
+## Ownership and support
+
+| Concern | Owner |
+| --- | --- |
+| TensorDict data, nested keys, tensor specs, modules, collectors, environments, replay, losses, and exploration | TensorDict / TorchRL |
+| Hooks, activation and gradient access, attribution, probing, patching, steering, pipeline planning, artifacts, and pass counts | TDHook |
+| Typed RL interaction semantics, validation, lifecycle restoration, binding to TDHook, compatibility, and provenance | XDRL |
+
+Supported execution is local and synchronous: direct TensorDict module calls, synchronous collector policies, deterministic evaluation, replay/loss calls, targets, and optimisation/backward contexts. Recurrent execution is limited to direct, synchronous, and replay-sequence state lifecycles. Compiled, remote, distributed, multiprocessing, asynchronous-collector, CUDA-graph, and worker-copied hook paths are unsupported unless a later version names new conformance evidence.
+
+Installation alone is not compatibility evidence. Call `validate_runtime_compatibility()` and name the relevant conformance suite before claiming support.
+
+## Typed observation
+
+<!-- runnable-example -->
+```python
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from xdrl import (
+    BatchSemantics,
+    InteractionDescriptor,
+    InteractionPhase,
+    KeyPresence,
+    KeyRole,
+    KeySchema,
+    ModelRole,
+    ObservationTrace,
+    RuntimeInteractionContext,
+    SchemaSnapshot,
+    TensorDictSchema,
+)
+
+inputs = TensorDictSchema(
+    (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),),
+    BatchSemantics(("env",)),
+)
+outputs = TensorDictSchema(
+    (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),),
+    BatchSemantics(("env",)),
+)
+policy = TensorDictModule(torch.nn.Linear(4, 2), in_keys=["observation"], out_keys=["action"])
+batch = TensorDict({"observation": torch.randn(8, 4)}, batch_size=[8])
+descriptor = InteractionDescriptor(
+    identity="actor:evaluation:0",
+    role=ModelRole.ACTOR,
+    phase=InteractionPhase.EVALUATION,
+    module_path="policy",
+    input_schema=SchemaSnapshot.from_schema(inputs),
+    output_schema=SchemaSnapshot.from_schema(outputs),
+    batch_dimensions=("env",),
+    model_id="actor-v1",
+    checkpoint_id="sha256:example",
+    exploration_mode="deterministic",
+    module_training=False,
+)
+trace = ObservationTrace()  # metadata-only retention is the safe default
+interaction = RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch, observations=trace)
+result = interaction(batch.clone())
+
+assert result["action"].shape == (8, 2)
+assert trace.records and all(record.payload is None for record in trace.records)
+```
+
+For opt-in payloads, construct `RetentionPolicy` with `TensorRetention.DETACHED` or `CPU`, named `DimensionReduction` operations, and a bounded record policy. Observation-only output parity is owned by `tests/behavioural_parity/test_tdhook_adapter.py`; tensor retention is not a license to keep unbounded rollout data.
+
+## Checked intervention and paired execution
+
+<!-- runnable-example -->
+```python
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from xdrl import (
+    BatchSemantics,
+    InteractionDescriptor,
+    InteractionPhase,
+    Intervention,
+    InterventionController,
+    InterventionTarget,
+    InterventionTiming,
+    KeyPresence,
+    KeyRole,
+    KeySchema,
+    ModelRole,
+    RuntimeInteractionContext,
+    SchemaSnapshot,
+    TensorDictSchema,
+    run_paired,
+)
+
+inputs = TensorDictSchema(
+    (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),),
+    BatchSemantics(("env",)),
+)
+outputs = TensorDictSchema(
+    (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),),
+    BatchSemantics(("env",)),
+)
+policy = TensorDictModule(torch.nn.Linear(2, 1, bias=False), in_keys=["observation"], out_keys=["action"])
+batch = TensorDict({"observation": torch.ones(2, 2)}, batch_size=[2])
+descriptor = InteractionDescriptor(
+    "actor:evaluation:paired",
+    ModelRole.ACTOR,
+    InteractionPhase.EVALUATION,
+    "policy",
+    SchemaSnapshot.from_schema(inputs),
+    SchemaSnapshot.from_schema(outputs),
+    batch_dimensions=("env",),
+    checkpoint_id="checkpoint-1",
+)
+baseline = RuntimeInteractionContext(descriptor, policy, inputs, outputs, batch)
+edit = Intervention(
+    "add-one",
+    InterventionTarget.TENSORDICT,
+    InterventionTiming.OUTPUT,
+    transform=lambda value: value + 1,
+    key="action",
+)
+steered = RuntimeInteractionContext(
+    descriptor,
+    policy,
+    inputs,
+    outputs,
+    batch,
+    interventions=InterventionController((edit,)),
+)
+pair = run_paired(baseline, steered, batch)
+
+assert torch.equal(pair.intervention["action"], pair.baseline["action"] + 1)
+assert pair.checkpoint_id == "checkpoint-1"
+```
+
+Use `TDHookInterventionFactory` for activation or gradient targets, then pass it to `TDHookInteractionAdapter.activate`. A transform must preserve shape, dtype, and device. Paired execution provides matched mechanics and provenance, not a causal conclusion.
+
+## Recurrent and multi-agent declarations
+
+<!-- runnable-example -->
+```python
+import json
+
+from xdrl import (
+    AgentSelector,
+    BatchSemantics,
+    InteractionDescriptor,
+    InteractionPhase,
+    InteractionTopology,
+    KeyPresence,
+    KeyRole,
+    KeySchema,
+    ModelRole,
+    MultiAgentSemantics,
+    RecurrentCollectorMode,
+    RecurrentSemantics,
+    RecurrentStateTransition,
+    SchemaSnapshot,
+    SemanticTarget,
+    TensorDictSchema,
+)
+
+inputs = TensorDictSchema(
+    (
+        KeySchema("state", KeyRole.STATE, KeyPresence.REQUIRED),
+        KeySchema("is_init", KeyRole.TERMINATION, KeyPresence.REQUIRED),
+    ),
+    BatchSemantics(("env", "time")),
+)
+outputs = TensorDictSchema(
+    (KeySchema(("next", "state"), KeyRole.STATE, KeyPresence.PRODUCED),),
+    BatchSemantics(("env", "time")),
+)
+recurrent = RecurrentSemantics(
+    transitions=(RecurrentStateTransition(("state",), ("next", "state")),),
+    reset_keys=(("is_init",),),
+    sequence_dimension="time",
+    burn_in=2,
+    truncated_window=8,
+    collector_mode=RecurrentCollectorMode.REPLAY_SEQUENCE,
+)
+multi_agent = MultiAgentSemantics(
+    topology=InteractionTopology.PARAMETER_SHARED,
+    group="agents",
+    n_agents=3,
+    target=SemanticTarget(ModelRole.ACTOR, AgentSelector("agents")),
+)
+descriptor = InteractionDescriptor(
+    "actor:replay:0",
+    ModelRole.ACTOR,
+    InteractionPhase.REPLAY,
+    "policy.rnn",
+    SchemaSnapshot.from_schema(inputs),
+    SchemaSnapshot.from_schema(outputs),
+    batch_dimensions=("env", "time"),
+    time_dimension="time",
+    agent_dimension="agent",
+    recurrent=recurrent,
+    multi_agent=multi_agent,
+)
+encoded = json.loads(json.dumps(descriptor.to_dict()))
+
+assert encoded["recurrent"]["collector_mode"] == "replay_sequence"
+assert encoded["multi_agent"]["target"]["selector"]["group"] == "agents"
+```
+
+Required recurrent state must map to produced next state, reset masks must be declared inputs, and the sequence dimension must match the descriptor. Multi-agent targeting uses group, agent selection, role, and topology rather than Python module identity.
+
+## TDHook binding, plans, and provenance
+
+Use `TDHookInteractionAdapter(interaction, aliases={...})` to resolve stable semantic aliases to TDHook paths. For one or more raw factories, enter `with adapter.activate(factory) as active:` and call `active.invoke(batch)`. Materialise lazy modules explicitly with `adapter.materialize()` before activation.
+
+For a TDHook `Pipeline`, call `adapter.run_pipeline(pipeline, artifacts, code_revision=..., seed=...)`. TDHook remains the owner of planning, stage grouping, artifacts, and pass count; XDRL validates every planned model call and returns `TDHookPipelineResult` with per-stage `interaction_provenance`.
+
+For direct factories, capture a `ProvenanceManifest` with the descriptor, selected keys, `adapter.target_paths`, serialisable TDHook method configuration, exact dependency versions, and code revision. `to_json()` is deterministic. Provenance establishes reproducibility metadata; it does not establish support or scientific validity.
+
+## Evidence map
+
+- `tests/unit`: local schema, interaction, observation, intervention, recurrent, and multi-agent contracts.
+- `tests/integration`: XDRL/TorchRL/TDHook composition, planned workflows, and provenance.
+- `tests/upstream_compatibility`: version-sensitive and private upstream boundaries.
+- `tests/behavioural_parity`: native versus observation-only instrumented output parity.
+
+State install/import, runtime compatibility, named conformance results, supported execution mode, and behavioral conclusions separately.

--- a/skills/xdrl-library/references/xdrl-0.1.md
+++ b/skills/xdrl-library/references/xdrl-0.1.md
@@ -14,6 +14,8 @@ Supported execution is local and synchronous: direct TensorDict module calls, sy
 
 Installation alone is not compatibility evidence. Call `validate_runtime_compatibility()` and name the relevant conformance suite before claiming support.
 
+`BatchSemantics` assigns semantic labels to positional leading TensorDict batch axes. For example, `BatchSemantics(("env",))` declares that the sole axis in `batch_size=[8]` means `env`; the runtime validates the number and order of axes, while TensorDict stores their positional sizes rather than their XDRL labels. Preserve that declared ordering when constructing batches and interpreting named reductions.
+
 ## Typed observation
 
 <!-- runnable-example -->

--- a/skills/xdrl-library/references/xdrl-0.1.md
+++ b/skills/xdrl-library/references/xdrl-0.1.md
@@ -67,7 +67,7 @@ assert result["action"].shape == (8, 2)
 assert trace.records and all(record.payload is None for record in trace.records)
 ```
 
-For opt-in payloads, construct `RetentionPolicy` with `TensorRetention.DETACHED` or `CPU`, named `DimensionReduction` operations, and a bounded record policy. Observation-only output parity is owned by `tests/behavioural_parity/test_tdhook_adapter.py`; tensor retention is not a license to keep unbounded rollout data.
+For opt-in payloads, construct `RetentionPolicy` with `TensorRetention.DETACHED` or `CPU`, named `DimensionReduction` operations, and a bounded record policy. The metadata-only trace flow above is exercised by `tests/unit/test_observations.py::test_trace_is_serialisable_and_observation_only_preserves_model_output`; TDHook adapter parity is covered separately by `tests/behavioural_parity/test_tdhook_adapter.py`. Tensor retention is not a license to keep unbounded rollout data.
 
 ## Checked intervention and paired execution
 

--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -28,6 +28,7 @@ from xdrl.interactions import (
     RecurrentSemantics,
     RecurrentStateTransition,
     RuntimeInteractionContext,
+    SchemaSnapshot,
     SemanticTarget,
 )
 from xdrl.interventions import (
@@ -53,7 +54,14 @@ from xdrl.observations import (
 )
 from xdrl.provenance import PROVENANCE_SCHEMA_REVISION, ProvenanceManifest, ProvenanceSchemaError
 from xdrl.tdhook import TDHookInteractionAdapter, TDHookPipelineResult
-from xdrl.types import ModelRole, TensorDictSchema
+from xdrl.types import (
+    BatchSemantics,
+    KeyPresence,
+    KeyRole,
+    KeySchema,
+    ModelRole,
+    TensorDictSchema,
+)
 
 try:
     __version__ = version("xdrl")
@@ -62,11 +70,14 @@ except PackageNotFoundError:
 
 __all__ = [
     "ADAPTER_CONFORMANCE",
+    "AgentSelector",
+    "BatchSemantics",
     "CompatibilityBoundaryError",
     "ConformanceCheck",
     "ConformanceSuite",
     "GitRevisionRequirement",
     "InteractionDescriptor",
+    "InteractionPhase",
     "InteractionTopology",
     "Intervention",
     "InterventionController",
@@ -75,8 +86,9 @@ __all__ = [
     "InterventionTarget",
     "InterventionTiming",
     "InterventionValidationError",
-    "InteractionPhase",
-    "AgentSelector",
+    "KeyPresence",
+    "KeyRole",
+    "KeySchema",
     "MultiAgentSemantics",
     "ModelRole",
     "ObservationKind",
@@ -94,6 +106,7 @@ __all__ = [
     "RecurrentStateTransition",
     "RetentionPolicy",
     "RuntimeInteractionContext",
+    "SchemaSnapshot",
     "SemanticTarget",
     "SUPPORTED_DEPENDENCIES",
     "SUPPORTED_GIT_REVISIONS",

--- a/tests/integration/test_library_skill.py
+++ b/tests/integration/test_library_skill.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import zipfile
+
+import pytest
+from setuptools.build_meta import build_wheel
+
+import xdrl
+
+
+ROOT = Path(__file__).parents[2]
+SKILL = ROOT / "skills" / "xdrl-library"
+REFERENCE = SKILL / "references" / "xdrl-0.1.md"
+
+
+def _runnable_examples(markdown: str) -> list[str]:
+    return re.findall(r"<!-- runnable-example -->\s*```python\n(.*?)```", markdown, re.DOTALL)
+
+
+@pytest.mark.integration
+def test_skill_examples_use_the_installed_public_api(tmp_path: Path) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    wheel = dist / build_wheel(str(dist))
+    installed = tmp_path / "installed"
+    with zipfile.ZipFile(wheel) as archive:
+        archive.extractall(installed)
+
+    examples = _runnable_examples(REFERENCE.read_text())
+    assert len(examples) == 3
+    for index, example in enumerate(examples):
+        script = tmp_path / f"example_{index}.py"
+        script.write_text(
+            "from pathlib import Path\n"
+            "import xdrl\n"
+            f"assert Path(xdrl.__file__).is_relative_to(Path({str(installed)!r}))\n"
+            f"assert xdrl.__version__ == {xdrl.__version__!r}\n"
+            + example
+        )
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = str(installed)
+        environment["PYTHONNOUSERSITE"] = "1"
+        subprocess.run(
+            [sys.executable, str(script)],
+            cwd=tmp_path,
+            env=environment,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+
+def test_skill_is_versioned_and_names_evidence_boundaries() -> None:
+    skill = (SKILL / "SKILL.md").read_text()
+    reference = REFERENCE.read_text()
+
+    assert "xdrl.__version__" in skill
+    assert f"xdrl=={xdrl.__version__.rsplit('.', 1)[0]}.*" in reference
+    assert "Installation alone is not compatibility evidence" in reference
+    assert "tests/behavioural_parity" in reference
+    assert "compiled" in reference.casefold() and "distributed" in reference.casefold()

--- a/tests/integration/test_library_skill.py
+++ b/tests/integration/test_library_skill.py
@@ -61,5 +61,9 @@ def test_skill_is_versioned_and_names_evidence_boundaries() -> None:
     assert "xdrl.__version__" in skill
     assert f"xdrl=={xdrl.__version__.rsplit('.', 1)[0]}.*" in reference
     assert "Installation alone is not compatibility evidence" in reference
+    assert (
+        "tests/unit/test_observations.py::test_trace_is_serialisable_and_observation_only_preserves_model_output"
+        in reference
+    )
     assert "tests/behavioural_parity" in reference
     assert "compiled" in reference.casefold() and "distributed" in reference.casefold()

--- a/tests/integration/test_library_skill.py
+++ b/tests/integration/test_library_skill.py
@@ -39,8 +39,7 @@ def test_skill_examples_use_the_installed_public_api(tmp_path: Path) -> None:
             "from pathlib import Path\n"
             "import xdrl\n"
             f"assert Path(xdrl.__file__).is_relative_to(Path({str(installed)!r}))\n"
-            f"assert xdrl.__version__ == {xdrl.__version__!r}\n"
-            + example
+            f"assert xdrl.__version__ == {xdrl.__version__!r}\n" + example
         )
         environment = os.environ.copy()
         environment["PYTHONPATH"] = str(installed)

--- a/tests/integration/test_library_skill.py
+++ b/tests/integration/test_library_skill.py
@@ -61,6 +61,7 @@ def test_skill_is_versioned_and_names_evidence_boundaries() -> None:
     assert "xdrl.__version__" in skill
     assert f"xdrl=={xdrl.__version__.rsplit('.', 1)[0]}.*" in reference
     assert "Installation alone is not compatibility evidence" in reference
+    assert "semantic labels to positional leading TensorDict batch axes" in reference
     assert (
         "tests/unit/test_observations.py::test_trace_is_serialisable_and_observation_only_preserves_model_output"
         in reference


### PR DESCRIPTION
## What changed

- add a concise `xdrl-library` agent skill with Codex UI metadata and an `xdrl==0.1.*` reference;
- document the XDRL/TorchRL/TensorDict/TDHook ownership boundary, typed interactions, observation, intervention, recurrent and multi-agent semantics, planned TDHook workflows, provenance, and supported execution modes;
- expose the five existing schema-construction types required for public-namespace examples;
- exercise every runnable example from an extracted built wheel, outside the source checkout.

## Why

Issue #13 requires versioned agent guidance that uses the released public API and does not confuse installation with compatibility evidence. The construction types existed internally but were not available from the public `xdrl` namespace, so a complete public-namespace example could not be written without bypassing the package contract.

## User and developer impact

Coding agents get version-matched, evidence-aware guidance without introducing a trainer, data container, TDHook duplicate, or new runtime behavior. Unsupported compiled, remote, distributed, multiprocessing, asynchronous-collector, CUDA-graph, and worker-copied paths remain explicitly unsupported.

## Validation

- skill validator — passed
- `uv run pre-commit run --all-files` — passed
- `just tests` — 120 passed, 79.09% coverage
- `just docs` — passed with warnings treated as errors
- three documented examples — passed from an extracted wheel install path

closes #13