### PR TITLE
Align README header with TDHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
-# XDRL 🔍
+<div align="center">
+<img src="https://raw.githubusercontent.com/Xmaster6y/xdrl/refs/heads/main/docs/source/_static/images/xdrl-logo.png" alt="logo" width="200"/>
+</div>
+
+<h1 align=center><code>xdrl</code> 🔍</h1>
 
 [![Documentation](https://img.shields.io/badge/Documentation-blue.svg)](https://xdrl.readthedocs.io)
+[![xdrl](https://img.shields.io/pypi/v/xdrl?color=purple)](https://pypi.org/project/xdrl/)
 [![license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Xmaster6y/xdrl/blob/main/LICENSE)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![python versions](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-blue)](https://www.python.org/downloads/)
+[![python versions](https://img.shields.io/pypi/pyversions/xdrl.svg)](https://www.python.org/downloads/)
+
+[![codecov](https://codecov.io/gh/Xmaster6y/xdrl/graph/badge.svg)](https://codecov.io/gh/Xmaster6y/xdrl)
 ![ci](https://github.com/Xmaster6y/xdrl/actions/workflows/ci.yml/badge.svg)
+[![docs](https://readthedocs.org/projects/xdrl/badge/?version=latest)](https://xdrl.readthedocs.io/en/latest/?badge=latest)
 
 Typed model interactions for [TorchRL](https://github.com/pytorch/rl), with
 [TDHook](https://github.com/Xmaster6y/tdhook) observability and intervention.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/Xmaster6y/xdrl/refs/heads/main/docs/source/_static/images/xdrl-logo.png" alt="logo" width="200"/>
-</p>
 
 ## Getting Started
 


### PR DESCRIPTION
## What changed

Aligned the XDRL README header with TDHook's layout:

- centered logo above the title
- centered HTML package-name heading
- equivalent package, Python, Codecov, CI, and documentation badges
- badges and purpose text in the same order

## Validation

- git diff --check