### PR TITLE
Prepare v0.2.0 documentation and tag publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,22 +4,19 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    environment: publish
     permissions:
-      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           python-version: "3.11"
       - name: Verify tag matches the package version
-        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
           package_version=$(sed -n 's/^version = "\(.*\)"$/\1/p' pyproject.toml)
@@ -27,5 +24,24 @@ jobs:
           test "$package_version" = "$tag_version"
       - name: Build package
         run: uv build
+      - name: Upload package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      id-token: write
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: python-package-distributions
+          path: dist/
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+      - name: Verify tag matches the package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          package_version=$(sed -n 's/^version = "\(.*\)"$/\1/p' pyproject.toml)
+          tag_version="${GITHUB_REF_NAME#v}"
+          test "$package_version" = "$tag_version"
+      - name: Build package
+        run: uv build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -2,5 +2,9 @@
     {
       "version": "dev",
       "url": "https://xdrl.readthedocs.io/en/latest/"
+    },
+    {
+      "version": "v0.2.0",
+      "url": "https://xdrl.readthedocs.io/en/v0.2.0/"
     }
   ]


### PR DESCRIPTION
## What changed

- Adds `v0.2.0` to the Read the Docs version selector.
- Restores the PyPI trusted-publishing workflow.
- Publishes when a `v*` tag is pushed and verifies that the tag version matches `pyproject.toml` before building.

## Why

The prior workflow published only after a GitHub Release was marked published; pushing a version tag alone did not run it. The release path now matches the intended tag-driven workflow while preserving the existing `publish` environment and OIDC configuration.

## Release impact

After this PR is merged, create and push `v0.2.0` from the release commit to publish the matching package to PyPI.

## Validation

- `git diff --check`
- `uv build` (built the `xdrl-0.2.0` sdist and wheel)
