### PR TITLE
Support internally-complete TDHook autograd workflows

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,7 @@ build:
   tools:
     python: "3.11"
   commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
+    - python -m pip install --upgrade uv
     - uv pip install --system cmake
     - uv sync --locked
     - cd docs && uv run --group docs make html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ build-backend = "setuptools.build_meta"
 default-groups = ["dev", "docs"]
 
 [tool.uv.sources]
-tdhook = { git = "https://github.com/Xmaster6y/tdhook", rev = "ea51fe37094d19ddbdacb5db685583a5d1b88b3a" }
+tdhook = { git = "https://github.com/Xmaster6y/tdhook", branch = "main" }
 tensordict = { git = "https://github.com/pytorch/tensordict" }
 # TorchRL main currently selects nightly CPU wheels on macOS Python 3.11/3.13;
 # mirror that upstream split until its source policy is unified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ build-backend = "setuptools.build_meta"
 default-groups = ["dev", "docs"]
 
 [tool.uv.sources]
+tdhook = { git = "https://github.com/Xmaster6y/tdhook", rev = "ea51fe37094d19ddbdacb5db685583a5d1b88b3a" }
 tensordict = { git = "https://github.com/pytorch/tensordict" }
 # TorchRL main currently selects nightly CPU wheels on macOS Python 3.11/3.13;
 # mirror that upstream split until its source policy is unified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "packaging>=21.0",
-    "tdhook>=0.2,<0.3",
+    "tdhook @ git+https://github.com/Xmaster6y/tdhook@ea51fe37094d19ddbdacb5db685583a5d1b88b3a",
     "tensordict>=0.13,<0.14",
     "torch>=2.11",
     "torchrl>=0.13,<0.14",

--- a/src/xdrl/compatibility.py
+++ b/src/xdrl/compatibility.py
@@ -85,6 +85,7 @@ SUPPORTED_DEPENDENCIES = (
 SUPPORTED_GIT_REVISIONS = (
     GitRevisionRequirement("tensordict", "54a147b2d3c21ac407661a26e27a9b0c37e7fbd3"),
     GitRevisionRequirement("torchrl", "ae421b98d0dba86e5ab0b24917d1e64f376ee6f9"),
+    GitRevisionRequirement("tdhook", "ea51fe37094d19ddbdacb5db685583a5d1b88b3a"),
 )
 # dependency-snapshot: end
 

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -16,7 +16,7 @@ from typing import Any, Iterator
 import torch
 from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
-from tdhook.execution import AutogradLifetime, GradientMode
+from tdhook.execution import GradientMode
 from tdhook.workflow import Workflow, WorkflowPlan, WorkflowUpdate
 
 from xdrl.interactions import LifecycleEventType, RuntimeInteractionContext
@@ -116,10 +116,15 @@ class TDHookWorkflowRunner:
         contract = self.interaction.contract
         for execution in plan.executions:
             if execution.gradient_mode is GradientMode.REQUIRED:
-                if execution.autograd_lifetime is AutogradLifetime.BACKWARD:
+                autograd_lifetime = getattr(execution, "autograd_lifetime", None)
+                if getattr(autograd_lifetime, "value", autograd_lifetime) == "backward":
                     raise ValueError(
                         "deferred-backward TDHook workflows are unsupported because XDRL does not own the "
                         "caller-managed backward lifecycle"
+                    )
+                if autograd_lifetime is None:
+                    raise ValueError(
+                        "gradient-required TDHook execution requires a TDHook autograd lifetime declaration"
                     )
                 if contract.inference_mode:
                     raise ValueError("gradient-required TDHook execution is incompatible with inference_mode=True")

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -16,7 +16,7 @@ from typing import Any, Iterator
 import torch
 from tensordict import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
-from tdhook.execution import GradientMode
+from tdhook.execution import AutogradLifetime, GradientMode
 from tdhook.workflow import Workflow, WorkflowPlan, WorkflowUpdate
 
 from xdrl.interactions import LifecycleEventType, RuntimeInteractionContext
@@ -116,10 +116,15 @@ class TDHookWorkflowRunner:
         contract = self.interaction.contract
         for execution in plan.executions:
             if execution.gradient_mode is GradientMode.REQUIRED:
-                raise ValueError(
-                    "gradient-required TDHook workflows are unsupported because Workflow.run removes hook bindings "
-                    "before a caller-managed backward pass"
-                )
+                if execution.autograd_lifetime is AutogradLifetime.BACKWARD:
+                    raise ValueError(
+                        "deferred-backward TDHook workflows are unsupported because XDRL does not own the "
+                        "caller-managed backward lifecycle"
+                    )
+                if contract.inference_mode:
+                    raise ValueError("gradient-required TDHook execution is incompatible with inference_mode=True")
+                if not contract.gradient_enabled:
+                    raise ValueError("gradient-required TDHook execution requires gradient_enabled=True")
             if execution.gradient_mode is GradientMode.DISABLED and contract.gradient_enabled:
                 raise ValueError("gradient-disabled TDHook execution is incompatible with gradient_enabled=True")
 

--- a/tests/unit/test_tdhook.py
+++ b/tests/unit/test_tdhook.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
-from tdhook.execution import ExecutionSpec, GradientMode
+from tdhook.execution import AutogradLifetime, ExecutionSpec, GradientMode
 from tdhook.latent import ActivationCaching
 from tdhook.workflow import Workflow, WorkflowPlan
 
@@ -105,19 +105,82 @@ def test_workflow_gradient_requirements_must_match_the_rl_interaction() -> None:
         runner.run(workflow, runner.interaction.representative_input.clone(), code_revision="test-revision")
 
 
-def test_gradient_required_workflow_is_rejected_even_when_forward_gradients_are_enabled() -> None:
+class _InternalBackwardCaching(ActivationCaching):
+    @property
+    def execution_spec(self) -> ExecutionSpec:
+        return ExecutionSpec(gradient_mode=GradientMode.REQUIRED)
+
+
+class _DeferredBackwardCaching(ActivationCaching):
+    @property
+    def execution_spec(self) -> ExecutionSpec:
+        return ExecutionSpec(gradient_mode=GradientMode.REQUIRED, autograd_lifetime=AutogradLifetime.BACKWARD)
+
+
+class _InternalBackwardWorkflow(Workflow):
+    def run(self, model: torch.nn.Module, data: TensorDict) -> TensorDict:
+        result = super().run(model, data)
+        result.get(("agents", "action")).sum().backward()
+        return result
+
+
+def test_gradient_required_call_lifetime_workflow_runs_when_xdrl_owns_enabled_gradients() -> None:
     interaction = _interaction()
     interaction.contract = replace(interaction.contract, gradient_enabled=True)
     runner = TDHookWorkflowRunner(interaction)
 
-    with pytest.raises(ValueError, match="caller-managed backward pass"):
+    execution = runner.run(
+        _InternalBackwardWorkflow(_InternalBackwardCaching("module")),
+        interaction.representative_input.clone(),
+        code_revision="test-revision",
+    )
+
+    assert execution.plan.executions[0].autograd_lifetime is AutogradLifetime.CALL
+    assert interaction.module.module.weight.grad is not None
+    assert not interaction.module.module._forward_hooks
+
+
+def test_gradient_required_call_lifetime_workflow_requires_enabled_gradients() -> None:
+    runner = TDHookWorkflowRunner(_interaction())
+
+    with pytest.raises(ValueError, match="requires gradient_enabled=True"):
         runner.run(
-            Workflow(_RequiredGradientCaching("module")),
-            interaction.representative_input.clone(),
+            _InternalBackwardWorkflow(_InternalBackwardCaching("module")),
+            runner.interaction.representative_input.clone(),
             code_revision="test-revision",
         )
 
-    assert not interaction.events
+    assert not runner.interaction.events
+
+
+def test_gradient_required_call_lifetime_workflow_rejects_inference_mode() -> None:
+    interaction = _interaction()
+    interaction.contract = replace(interaction.contract, inference_mode=True)
+    runner = TDHookWorkflowRunner(interaction)
+
+    with pytest.raises(ValueError, match="incompatible with inference_mode=True"):
+        runner.run(
+            _InternalBackwardWorkflow(_InternalBackwardCaching("module")),
+            runner.interaction.representative_input.clone(),
+            code_revision="test-revision",
+        )
+
+    assert not runner.interaction.events
+
+
+def test_deferred_backward_workflow_remains_rejected() -> None:
+    interaction = _interaction()
+    interaction.contract = replace(interaction.contract, gradient_enabled=True)
+    runner = TDHookWorkflowRunner(interaction)
+
+    with pytest.raises(ValueError, match="deferred-backward"):
+        runner.run(
+            Workflow(_DeferredBackwardCaching("module")),
+            runner.interaction.representative_input.clone(),
+            code_revision="test-revision",
+        )
+
+    assert not runner.interaction.events
 
 
 class _DisabledGradientCaching(ActivationCaching):

--- a/tests/unit/test_tdhook.py
+++ b/tests/unit/test_tdhook.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -105,10 +106,12 @@ def test_workflow_gradient_requirements_must_match_the_rl_interaction() -> None:
         runner.run(workflow, runner.interaction.representative_input.clone(), code_revision="test-revision")
 
 
-class _InternalBackwardCaching(ActivationCaching):
-    @property
-    def execution_spec(self) -> ExecutionSpec:
-        return ExecutionSpec(gradient_mode=GradientMode.REQUIRED)
+def test_gradient_required_execution_without_a_lifetime_declaration_is_rejected() -> None:
+    runner = TDHookWorkflowRunner(_interaction())
+    plan = SimpleNamespace(executions=(SimpleNamespace(gradient_mode=GradientMode.REQUIRED),))
+
+    with pytest.raises(ValueError, match="autograd lifetime declaration"):
+        runner._validate_gradient_contract(plan)  # type: ignore[arg-type]
 
 
 class _DeferredBackwardCaching(ActivationCaching):
@@ -130,7 +133,7 @@ def test_gradient_required_call_lifetime_workflow_runs_when_xdrl_owns_enabled_gr
     runner = TDHookWorkflowRunner(interaction)
 
     execution = runner.run(
-        _InternalBackwardWorkflow(_InternalBackwardCaching("module")),
+        _InternalBackwardWorkflow(_RequiredGradientCaching("module")),
         interaction.representative_input.clone(),
         code_revision="test-revision",
     )
@@ -145,7 +148,7 @@ def test_gradient_required_call_lifetime_workflow_requires_enabled_gradients() -
 
     with pytest.raises(ValueError, match="requires gradient_enabled=True"):
         runner.run(
-            _InternalBackwardWorkflow(_InternalBackwardCaching("module")),
+            _InternalBackwardWorkflow(_RequiredGradientCaching("module")),
             runner.interaction.representative_input.clone(),
             code_revision="test-revision",
         )
@@ -160,7 +163,7 @@ def test_gradient_required_call_lifetime_workflow_rejects_inference_mode() -> No
 
     with pytest.raises(ValueError, match="incompatible with inference_mode=True"):
         runner.run(
-            _InternalBackwardWorkflow(_InternalBackwardCaching("module")),
+            _InternalBackwardWorkflow(_RequiredGradientCaching("module")),
             runner.interaction.representative_input.clone(),
             code_revision="test-revision",
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1541,15 +1541,11 @@ wheels = [
 [[package]]
 name = "tdhook"
 version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/Xmaster6y/tdhook?rev=ea51fe37094d19ddbdacb5db685583a5d1b88b3a#ea51fe37094d19ddbdacb5db685583a5d1b88b3a" }
 dependencies = [
     { name = "tensordict" },
     { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'" },
     { name = "torch", version = "2.14.0.dev20260805", source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }, marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/c8/2ac21e42bb02ffed5c3b951fe1d42874950b9bc6519d9e0db15748b96500/tdhook-0.2.0.tar.gz", hash = "sha256:e01bf8994d0506951f70f0b064b10b90484bae27211fa8a847ed05944b54beae", size = 86621, upload-time = "2026-08-05T09:02:06.168Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/36/809528e1e867177b819a15ff3f52129bf8bd76d985b87c120df9224cc2e9/tdhook-0.2.0-py3-none-any.whl", hash = "sha256:cb9f9ac6cf1f50ef6c5875f0d1c8b6384b17547e355ba95853b344e030f1c7eb", size = 83708, upload-time = "2026-08-05T09:02:04.771Z" },
 ]
 
 [[package]]
@@ -1809,7 +1805,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
-    { name = "tdhook", specifier = ">=0.2,<0.3" },
+    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?rev=ea51fe37094d19ddbdacb5db685583a5d1b88b3a" },
     { name = "tensordict", git = "https://github.com/pytorch/tensordict" },
     { name = "torch", marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'", specifier = ">=2.11", index = "https://pypi.org/simple" },
     { name = "torch", marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/nightly/cpu" },

--- a/uv.lock
+++ b/uv.lock
@@ -1541,7 +1541,7 @@ wheels = [
 [[package]]
 name = "tdhook"
 version = "0.2.0"
-source = { git = "https://github.com/Xmaster6y/tdhook?rev=ea51fe37094d19ddbdacb5db685583a5d1b88b3a#ea51fe37094d19ddbdacb5db685583a5d1b88b3a" }
+source = { git = "https://github.com/Xmaster6y/tdhook?branch=main#ea51fe37094d19ddbdacb5db685583a5d1b88b3a" }
 dependencies = [
     { name = "tensordict" },
     { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'" },
@@ -1805,7 +1805,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
-    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?rev=ea51fe37094d19ddbdacb5db685583a5d1b88b3a" },
+    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?branch=main" },
     { name = "tensordict", git = "https://github.com/pytorch/tensordict" },
     { name = "torch", marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'", specifier = ">=2.11", index = "https://pypi.org/simple" },
     { name = "torch", marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/nightly/cpu" },


### PR DESCRIPTION
Closes #43

## Summary
- admit required-gradient TDHook executions whose declared autograd lifetime ends with the workflow call
- keep deferred-backward workflows outside the XDRL boundary
- pin TDHook to the upstream revision that introduces the lifetime declaration, pending a release

## Validation
- `uv run pre-commit run --all-files`
- `uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -q` (134 passed; 93.40% coverage)