### PR TITLE
Record external inputs and result artifacts in workflow provenance

### DIFF
--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -53,6 +53,11 @@ from xdrl.observations import (
     TensorRetention,
 )
 from xdrl.provenance import (
+    ArtifactDigestAlgorithm,
+    InputArtifactReference,
+    InputArtifactRole,
+    OutputArtifactReference,
+    OutputArtifactRole,
     WORKFLOW_PROVENANCE_SCHEMA_REVISION,
     ProvenanceSchemaError,
     WorkflowCompatibilityEvidence,
@@ -82,6 +87,7 @@ except PackageNotFoundError:
 
 __all__ = [
     "AgentSelector",
+    "ArtifactDigestAlgorithm",
     "BatchSemantics",
     "CompatibilityBoundaryError",
     "ConformanceCheck",
@@ -98,6 +104,8 @@ __all__ = [
     "InterventionTarget",
     "InterventionTiming",
     "InterventionValidationError",
+    "InputArtifactReference",
+    "InputArtifactRole",
     "KeyPresence",
     "KeyRole",
     "KeySchema",
@@ -108,6 +116,8 @@ __all__ = [
     "ObservationKind",
     "ObservationRecord",
     "ObservationTrace",
+    "OutputArtifactReference",
+    "OutputArtifactRole",
     "PRIVATE_UPSTREAM_APIS",
     "PrivateAPIUsage",
     "ProvenanceSchemaError",

--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -56,6 +56,8 @@ from xdrl.provenance import (
     ArtifactDigestAlgorithm,
     InputArtifactReference,
     InputArtifactRole,
+    OutputArtifactDeclaration,
+    OutputArtifactDigest,
     OutputArtifactReference,
     OutputArtifactRole,
     WORKFLOW_PROVENANCE_SCHEMA_REVISION,
@@ -65,7 +67,7 @@ from xdrl.provenance import (
     WorkflowPlanEvidence,
     WorkflowProvenance,
 )
-from xdrl.tdhook import TDHookWorkflowResult, TDHookWorkflowRunner
+from xdrl.tdhook import OutputArtifactResolver, TDHookWorkflowResult, TDHookWorkflowRunner
 from xdrl.types import (
     BatchSemantics,
     ContractModule,
@@ -116,7 +118,10 @@ __all__ = [
     "ObservationKind",
     "ObservationRecord",
     "ObservationTrace",
+    "OutputArtifactDeclaration",
+    "OutputArtifactDigest",
     "OutputArtifactReference",
+    "OutputArtifactResolver",
     "OutputArtifactRole",
     "PRIVATE_UPSTREAM_APIS",
     "PrivateAPIUsage",

--- a/src/xdrl/provenance.py
+++ b/src/xdrl/provenance.py
@@ -78,6 +78,53 @@ _DIGEST_HEX_LENGTH = {
 
 
 @dataclass(frozen=True, slots=True)
+class OutputArtifactDigest:
+    """A digest resolved for one declared output after workflow execution."""
+
+    identity: str
+    digest_algorithm: ArtifactDigestAlgorithm
+    digest_value: str
+
+    def __post_init__(self) -> None:
+        _nonempty_string(self.identity, "output artifact digest.identity")
+        _validate_digest(
+            self.digest_algorithm,
+            self.digest_value,
+            "output artifact digest",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OutputArtifactDeclaration:
+    """Pre-execution identity and role for an output whose digest is resolved later."""
+
+    identity: str
+    role: OutputArtifactRole
+    source: str | None = None
+    revision: str | None = None
+    source_is_immutable: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_artifact_location(self, "output artifact declaration", OutputArtifactRole)
+
+    def resolve(self, digest: OutputArtifactDigest) -> OutputArtifactReference:
+        """Combine this declaration with a post-execution digest."""
+        if digest.identity != self.identity:
+            raise ProvenanceSchemaError("output artifact digest identity must match its declaration")
+        return OutputArtifactReference(
+            identity=self.identity,
+            role=self.role,
+            digest_algorithm=digest.digest_algorithm,
+            digest_value=digest.digest_value,
+            source=self.source,
+            revision=self.revision,
+            source_is_immutable=self.source_is_immutable,
+            metadata=self.metadata,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class InputArtifactReference:
     """Tensor-free identity for one external input used by a workflow."""
 
@@ -262,6 +309,42 @@ class WorkflowProvenance:
         resolved = installed_dependency_versions() if dependencies is None else dependencies
         _artifact_references(input_artifacts, output_artifacts)
         return _validate_dependencies(dict(resolved))
+
+    @classmethod
+    def validate_output_artifact_declarations(
+        cls,
+        input_artifacts: tuple[InputArtifactReference, ...],
+        output_artifacts: tuple[OutputArtifactDeclaration, ...],
+    ) -> tuple[OutputArtifactDeclaration, ...]:
+        """Validate declared output identities before workflow execution."""
+        return _output_artifact_declarations(input_artifacts, output_artifacts)
+
+    @classmethod
+    def resolve_output_artifacts(
+        cls,
+        declarations: tuple[OutputArtifactDeclaration, ...],
+        digests: tuple[OutputArtifactDigest, ...],
+    ) -> tuple[OutputArtifactReference, ...]:
+        """Bind post-execution digests to the exact declared output identities."""
+        if not isinstance(digests, (list, tuple)) or not all(
+            isinstance(item, OutputArtifactDigest) for item in digests
+        ):
+            raise ProvenanceSchemaError("output artifact resolver must return OutputArtifactDigest values")
+        by_identity = {item.identity: item for item in digests}
+        if len(by_identity) != len(digests):
+            raise ProvenanceSchemaError("output artifact resolver returned duplicate identities")
+        declared = {item.identity for item in declarations}
+        resolved = set(by_identity)
+        if declared != resolved:
+            missing = sorted(declared - resolved)
+            unknown = sorted(resolved - declared)
+            details = []
+            if missing:
+                details.append(f"missing identities: {', '.join(missing)}")
+            if unknown:
+                details.append(f"unknown identities: {', '.join(unknown)}")
+            raise ProvenanceSchemaError(f"output artifact resolver disagrees with declarations: {'; '.join(details)}")
+        return tuple(declaration.resolve(by_identity[declaration.identity]) for declaration in declarations)
 
     @classmethod
     def capture(
@@ -736,19 +819,26 @@ def _required_dependency_names() -> set[str]:
 
 
 def _validate_artifact_reference(value: Any, field: str) -> None:
-    _nonempty_string(value.identity, f"{field}.identity")
     expected_role = InputArtifactRole if isinstance(value, InputArtifactReference) else OutputArtifactRole
-    if not isinstance(value.role, expected_role):
-        raise ProvenanceSchemaError(f"{field}.role must be a {expected_role.__name__}")
-    if not isinstance(value.digest_algorithm, ArtifactDigestAlgorithm):
+    _validate_artifact_location(value, field, expected_role)
+    _validate_digest(value.digest_algorithm, value.digest_value, field)
+
+
+def _validate_digest(algorithm: Any, digest_value: Any, field: str) -> None:
+    if not isinstance(algorithm, ArtifactDigestAlgorithm):
         raise ProvenanceSchemaError(f"{field}.digest_algorithm must be an ArtifactDigestAlgorithm")
-    digest = _nonempty_string(value.digest_value, f"{field}.digest_value")
-    expected_length = _DIGEST_HEX_LENGTH[value.digest_algorithm]
+    digest = _nonempty_string(digest_value, f"{field}.digest_value")
+    expected_length = _DIGEST_HEX_LENGTH[algorithm]
     if len(digest) != expected_length or any(character not in "0123456789abcdef" for character in digest):
         raise ProvenanceSchemaError(
-            f"{field}.digest_value must be {expected_length} lowercase hexadecimal characters "
-            f"for {value.digest_algorithm.value}"
+            f"{field}.digest_value must be {expected_length} lowercase hexadecimal characters for {algorithm.value}"
         )
+
+
+def _validate_artifact_location(value: Any, field: str, role_type: Any) -> None:
+    _nonempty_string(value.identity, f"{field}.identity")
+    if not isinstance(value.role, role_type):
+        raise ProvenanceSchemaError(f"{field}.role must be a {role_type.__name__}")
     source = _optional_string(value.source, f"{field}.source")
     revision = _optional_string(value.revision, f"{field}.revision")
     if type(value.source_is_immutable) is not bool:
@@ -759,7 +849,7 @@ def _validate_artifact_reference(value: Any, field: str) -> None:
         raise ProvenanceSchemaError(f"{field}.source_is_immutable requires source")
     if source is not None and revision is None and not value.source_is_immutable:
         raise ProvenanceSchemaError(f"{field}.source requires a revision unless it is explicitly immutable")
-    metadata = _json_object(value.metadata, f"{field}.metadata")
+    metadata = _json_object(_thaw_json(value.metadata), f"{field}.metadata")
     object.__setattr__(value, "metadata", _freeze_json(metadata))
 
 
@@ -835,6 +925,24 @@ def _artifact_references(
     if duplicates:
         raise ProvenanceSchemaError(f"artifact identities must be unique: {', '.join(duplicates)}")
     return tuple(input_artifacts), tuple(output_artifacts)
+
+
+def _output_artifact_declarations(
+    input_artifacts: Any, output_artifacts: Any
+) -> tuple[OutputArtifactDeclaration, ...]:
+    if not isinstance(output_artifacts, (list, tuple)) or not all(
+        isinstance(item, OutputArtifactDeclaration) for item in output_artifacts
+    ):
+        raise ProvenanceSchemaError("output_artifacts must contain only OutputArtifactDeclaration values")
+    if not isinstance(input_artifacts, (list, tuple)) or not all(
+        isinstance(item, InputArtifactReference) for item in input_artifacts
+    ):
+        raise ProvenanceSchemaError("input_artifacts must contain only InputArtifactReference values")
+    identities = [item.identity for item in (*input_artifacts, *output_artifacts)]
+    duplicates = sorted({identity for identity in identities if identities.count(identity) > 1})
+    if duplicates:
+        raise ProvenanceSchemaError(f"artifact identities must be unique: {', '.join(duplicates)}")
+    return tuple(output_artifacts)
 
 
 def _mapping(value: Any, field: str) -> Mapping[str, Any]:
@@ -1012,6 +1120,8 @@ __all__ = [
     "InputArtifactReference",
     "InputArtifactRole",
     "OutputArtifactReference",
+    "OutputArtifactDeclaration",
+    "OutputArtifactDigest",
     "OutputArtifactRole",
     "ProvenanceSchemaError",
     "WORKFLOW_PROVENANCE_SCHEMA_REVISION",

--- a/src/xdrl/provenance.py
+++ b/src/xdrl/provenance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from dataclasses import MISSING, asdict, dataclass, fields
+from dataclasses import MISSING, asdict, dataclass, field, fields
 from enum import Enum
 from types import MappingProxyType
 from typing import Any
@@ -28,11 +28,107 @@ from xdrl.interactions import (
 )
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
-WORKFLOW_PROVENANCE_SCHEMA_REVISION = 2
+WORKFLOW_PROVENANCE_SCHEMA_REVISION = 3
 
 
 class ProvenanceSchemaError(ValueError):
     """A workflow provenance payload violates the current schema."""
+
+
+class ArtifactDigestAlgorithm(str, Enum):
+    """Supported cryptographic digest algorithms for external artifacts."""
+
+    SHA256 = "sha256"
+    SHA384 = "sha384"
+    SHA512 = "sha512"
+    BLAKE2B = "blake2b"
+    BLAKE2S = "blake2s"
+
+
+class InputArtifactRole(str, Enum):
+    """The declared role an external input plays in a workflow run."""
+
+    MODEL_CHECKPOINT = "model_checkpoint"
+    DATASET = "dataset"
+    ENVIRONMENT_BUILD = "environment_build"
+    EVALUATION_SPLIT = "evaluation_split"
+    LEVEL_SET = "level_set"
+    REFERENCE_RESULT = "reference_result"
+    OTHER = "other"
+
+
+class OutputArtifactRole(str, Enum):
+    """The declared role of an artifact emitted by a workflow run."""
+
+    METRICS_BUNDLE = "metrics_bundle"
+    OBSERVATION_TRACE = "observation_trace"
+    ATTRIBUTION = "attribution"
+    INTERVENTION_RESULT = "intervention_result"
+    FIGURE = "figure"
+    OTHER = "other"
+
+
+_DIGEST_HEX_LENGTH = {
+    ArtifactDigestAlgorithm.SHA256: 64,
+    ArtifactDigestAlgorithm.SHA384: 96,
+    ArtifactDigestAlgorithm.SHA512: 128,
+    ArtifactDigestAlgorithm.BLAKE2B: 128,
+    ArtifactDigestAlgorithm.BLAKE2S: 64,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class InputArtifactReference:
+    """Tensor-free identity for one external input used by a workflow."""
+
+    identity: str
+    role: InputArtifactRole
+    digest_algorithm: ArtifactDigestAlgorithm
+    digest_value: str
+    source: str | None = None
+    revision: str | None = None
+    source_is_immutable: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_artifact_reference(self, "input artifact")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a detached JSON-compatible representation."""
+        return _artifact_reference_dict(self)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> InputArtifactReference:
+        """Strictly decode one input artifact reference."""
+        values = _artifact_reference_values(payload, "input artifact", InputArtifactRole)
+        return cls(**values)
+
+
+@dataclass(frozen=True, slots=True)
+class OutputArtifactReference:
+    """Tensor-free identity for one result artifact emitted by a workflow."""
+
+    identity: str
+    role: OutputArtifactRole
+    digest_algorithm: ArtifactDigestAlgorithm
+    digest_value: str
+    source: str | None = None
+    revision: str | None = None
+    source_is_immutable: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_artifact_reference(self, "output artifact")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a detached JSON-compatible representation."""
+        return _artifact_reference_dict(self)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> OutputArtifactReference:
+        """Strictly decode one output artifact reference."""
+        values = _artifact_reference_values(payload, "output artifact", OutputArtifactRole)
+        return cls(**values)
 
 
 @dataclass(frozen=True, slots=True)
@@ -113,6 +209,8 @@ class WorkflowProvenance:
     lifecycle_events: tuple[LifecycleEvent, ...]
     dependencies: Mapping[str, str]
     code_revision: str
+    input_artifacts: tuple[InputArtifactReference, ...]
+    output_artifacts: tuple[OutputArtifactReference, ...]
     seed: int | None = None
 
     def __post_init__(self) -> None:
@@ -128,6 +226,7 @@ class WorkflowProvenance:
             raise ProvenanceSchemaError("seed must be an integer or null")
         dependencies = _validate_dependencies(self.dependencies)
         configured_steps = _configured_step_sequence(self.configured_steps)
+        input_artifacts, output_artifacts = _artifact_references(self.input_artifacts, self.output_artifacts)
         if any(event.interaction_id != interaction_id for event in self.lifecycle_events):
             raise ProvenanceSchemaError("lifecycle events must belong to the interaction contract")
         if self.model_calls != self.workflow_plan.model_passes:
@@ -139,6 +238,8 @@ class WorkflowProvenance:
         object.__setattr__(self, "interaction_contract", _freeze_json(contract))
         object.__setattr__(self, "configured_steps", configured_steps)
         object.__setattr__(self, "dependencies", MappingProxyType(dependencies))
+        object.__setattr__(self, "input_artifacts", input_artifacts)
+        object.__setattr__(self, "output_artifacts", output_artifacts)
         try:
             json.dumps(self.to_dict(), sort_keys=True, allow_nan=False)
         except (TypeError, ValueError) as error:
@@ -151,12 +252,15 @@ class WorkflowProvenance:
         code_revision: str,
         seed: int | None = None,
         dependencies: Mapping[str, str] | None = None,
+        input_artifacts: tuple[InputArtifactReference, ...] = (),
+        output_artifacts: tuple[OutputArtifactReference, ...] = (),
     ) -> dict[str, str]:
         """Validate reproduction metadata before a workflow mutates live state."""
         _nonempty_string(code_revision, "code_revision")
         if seed is not None and type(seed) is not int:
             raise ProvenanceSchemaError("seed must be an integer or null")
         resolved = installed_dependency_versions() if dependencies is None else dependencies
+        _artifact_references(input_artifacts, output_artifacts)
         return _validate_dependencies(dict(resolved))
 
     @classmethod
@@ -170,12 +274,16 @@ class WorkflowProvenance:
         code_revision: str,
         seed: int | None = None,
         dependencies: Mapping[str, str] | None = None,
+        input_artifacts: tuple[InputArtifactReference, ...] = (),
+        output_artifacts: tuple[OutputArtifactReference, ...] = (),
     ) -> WorkflowProvenance:
         """Capture verified workflow evidence from public XDRL and TDHook state."""
         validated_dependencies = cls.validate_run_metadata(
             code_revision=code_revision,
             seed=seed,
             dependencies=dependencies,
+            input_artifacts=input_artifacts,
+            output_artifacts=output_artifacts,
         )
         return cls(
             schema_revision=WORKFLOW_PROVENANCE_SCHEMA_REVISION,
@@ -185,6 +293,8 @@ class WorkflowProvenance:
             lifecycle_events=events,
             dependencies=validated_dependencies,
             code_revision=code_revision,
+            input_artifacts=input_artifacts,
+            output_artifacts=output_artifacts,
             seed=seed,
         )
 
@@ -208,6 +318,8 @@ class WorkflowProvenance:
             "lifecycle_events": [event.to_dict() for event in self.lifecycle_events],
             "dependencies": dict(self.dependencies),
             "code_revision": self.code_revision,
+            "input_artifacts": [artifact.to_dict() for artifact in self.input_artifacts],
+            "output_artifacts": [artifact.to_dict() for artifact in self.output_artifacts],
             "seed": self.seed,
         }
         return _json_copy(payload, "workflow provenance")
@@ -221,6 +333,17 @@ class WorkflowProvenance:
         """Decode provenance while rejecting unknown revisions or fields."""
         if not isinstance(payload, Mapping):
             raise ProvenanceSchemaError("workflow provenance must contain an object")
+        revision = payload.get("schema_revision")
+        if type(revision) is not int or revision != WORKFLOW_PROVENANCE_SCHEMA_REVISION:
+            if revision == 2:
+                raise ProvenanceSchemaError(
+                    "workflow provenance schema revision 2 predates artifact references and cannot be migrated "
+                    "without caller-supplied artifact identities; decode it with an XDRL version that supports revision 2"
+                )
+            raise ProvenanceSchemaError(
+                f"unsupported workflow provenance schema revision {revision!r}; "
+                f"expected {WORKFLOW_PROVENANCE_SCHEMA_REVISION}"
+            )
         model_fields = fields(cls)
         known = {item.name for item in model_fields}
         required = {item.name for item in model_fields if item.default is MISSING and item.default_factory is MISSING}
@@ -233,17 +356,13 @@ class WorkflowProvenance:
             if unknown:
                 details.append(f"unknown fields: {', '.join(sorted(unknown))}")
             raise ProvenanceSchemaError("; ".join(details))
-        revision = payload["schema_revision"]
-        if type(revision) is not int or revision != WORKFLOW_PROVENANCE_SCHEMA_REVISION:
-            raise ProvenanceSchemaError(
-                f"unsupported workflow provenance schema revision {revision!r}; "
-                f"expected {WORKFLOW_PROVENANCE_SCHEMA_REVISION}"
-            )
         contract = _contract_projection(payload["interaction_contract"])
         plan = _plan_evidence(payload["workflow_plan"])
         configured_steps = _configured_steps(payload["configured_steps"])
         events = _lifecycle_events(payload["lifecycle_events"])
         dependencies = _validate_dependencies(_string_mapping(payload["dependencies"], "dependencies"))
+        input_artifacts = _decoded_artifacts(payload["input_artifacts"], "input_artifacts", InputArtifactReference)
+        output_artifacts = _decoded_artifacts(payload["output_artifacts"], "output_artifacts", OutputArtifactReference)
         seed = payload.get("seed")
         if seed is not None and type(seed) is not int:
             raise ProvenanceSchemaError("seed must be an integer or null")
@@ -255,6 +374,8 @@ class WorkflowProvenance:
             lifecycle_events=events,
             dependencies=dependencies,
             code_revision=_nonempty_string(payload["code_revision"], "code_revision"),
+            input_artifacts=input_artifacts,
+            output_artifacts=output_artifacts,
             seed=seed,
         )
 
@@ -614,6 +735,108 @@ def _required_dependency_names() -> set[str]:
     return {"python", "torch", "tensordict", "torchrl", "tdhook", "xdrl"}
 
 
+def _validate_artifact_reference(value: Any, field: str) -> None:
+    _nonempty_string(value.identity, f"{field}.identity")
+    expected_role = InputArtifactRole if isinstance(value, InputArtifactReference) else OutputArtifactRole
+    if not isinstance(value.role, expected_role):
+        raise ProvenanceSchemaError(f"{field}.role must be a {expected_role.__name__}")
+    if not isinstance(value.digest_algorithm, ArtifactDigestAlgorithm):
+        raise ProvenanceSchemaError(f"{field}.digest_algorithm must be an ArtifactDigestAlgorithm")
+    digest = _nonempty_string(value.digest_value, f"{field}.digest_value")
+    expected_length = _DIGEST_HEX_LENGTH[value.digest_algorithm]
+    if len(digest) != expected_length or any(character not in "0123456789abcdef" for character in digest):
+        raise ProvenanceSchemaError(
+            f"{field}.digest_value must be {expected_length} lowercase hexadecimal characters "
+            f"for {value.digest_algorithm.value}"
+        )
+    source = _optional_string(value.source, f"{field}.source")
+    revision = _optional_string(value.revision, f"{field}.revision")
+    if type(value.source_is_immutable) is not bool:
+        raise ProvenanceSchemaError(f"{field}.source_is_immutable must be a boolean")
+    if revision is not None and source is None:
+        raise ProvenanceSchemaError(f"{field}.revision requires source")
+    if value.source_is_immutable and source is None:
+        raise ProvenanceSchemaError(f"{field}.source_is_immutable requires source")
+    if source is not None and revision is None and not value.source_is_immutable:
+        raise ProvenanceSchemaError(f"{field}.source requires a revision unless it is explicitly immutable")
+    metadata = _json_object(value.metadata, f"{field}.metadata")
+    object.__setattr__(value, "metadata", _freeze_json(metadata))
+
+
+def _artifact_reference_dict(value: InputArtifactReference | OutputArtifactReference) -> dict[str, Any]:
+    return {
+        "identity": value.identity,
+        "role": value.role.value,
+        "digest_algorithm": value.digest_algorithm.value,
+        "digest_value": value.digest_value,
+        "source": value.source,
+        "revision": value.revision,
+        "source_is_immutable": value.source_is_immutable,
+        "metadata": _thaw_json(value.metadata),
+    }
+
+
+def _artifact_reference_values(
+    payload: Mapping[str, Any], field: str, role_type: type[InputArtifactRole] | type[OutputArtifactRole]
+) -> dict[str, Any]:
+    entry = _exact_mapping(
+        payload,
+        field,
+        {
+            "identity",
+            "role",
+            "digest_algorithm",
+            "digest_value",
+            "source",
+            "revision",
+            "source_is_immutable",
+            "metadata",
+        },
+    )
+    try:
+        role = role_type(entry["role"])
+    except (TypeError, ValueError) as error:
+        raise ProvenanceSchemaError(f"{field}.role must be a known string value") from error
+    try:
+        algorithm = ArtifactDigestAlgorithm(entry["digest_algorithm"])
+    except (TypeError, ValueError) as error:
+        raise ProvenanceSchemaError(f"{field}.digest_algorithm must be a known string value") from error
+    return {
+        "identity": entry["identity"],
+        "role": role,
+        "digest_algorithm": algorithm,
+        "digest_value": entry["digest_value"],
+        "source": entry["source"],
+        "revision": entry["revision"],
+        "source_is_immutable": entry["source_is_immutable"],
+        "metadata": entry["metadata"],
+    }
+
+
+def _decoded_artifacts(value: Any, field: str, artifact_type: Any) -> tuple[Any, ...]:
+    if not isinstance(value, list):
+        raise ProvenanceSchemaError(f"{field} must be an array")
+    return tuple(artifact_type.from_dict(item) for item in value)
+
+
+def _artifact_references(
+    input_artifacts: Any, output_artifacts: Any
+) -> tuple[tuple[InputArtifactReference, ...], tuple[OutputArtifactReference, ...]]:
+    if not isinstance(input_artifacts, (list, tuple)) or not all(
+        isinstance(item, InputArtifactReference) for item in input_artifacts
+    ):
+        raise ProvenanceSchemaError("input_artifacts must contain only InputArtifactReference values")
+    if not isinstance(output_artifacts, (list, tuple)) or not all(
+        isinstance(item, OutputArtifactReference) for item in output_artifacts
+    ):
+        raise ProvenanceSchemaError("output_artifacts must contain only OutputArtifactReference values")
+    identities = [item.identity for item in (*input_artifacts, *output_artifacts)]
+    duplicates = sorted({identity for identity in identities if identities.count(identity) > 1})
+    if duplicates:
+        raise ProvenanceSchemaError(f"artifact identities must be unique: {', '.join(duplicates)}")
+    return tuple(input_artifacts), tuple(output_artifacts)
+
+
 def _mapping(value: Any, field: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
         raise ProvenanceSchemaError(f"{field} must be an object with string keys")
@@ -785,6 +1008,11 @@ def _thaw_json(value: Any) -> Any:
 
 
 __all__ = [
+    "ArtifactDigestAlgorithm",
+    "InputArtifactReference",
+    "InputArtifactRole",
+    "OutputArtifactReference",
+    "OutputArtifactRole",
     "ProvenanceSchemaError",
     "WORKFLOW_PROVENANCE_SCHEMA_REVISION",
     "WorkflowCompatibilityEvidence",

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -8,7 +8,7 @@ plan-to-call-count evidence around every actual root model call.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
 import torch
@@ -18,7 +18,17 @@ from tdhook.execution import GradientMode
 from tdhook.workflow import Workflow, WorkflowPlan, WorkflowUpdate
 
 from xdrl.interactions import LifecycleEventType, RuntimeInteractionContext
-from xdrl.provenance import InputArtifactReference, OutputArtifactReference, WorkflowProvenance
+from xdrl.provenance import (
+    InputArtifactReference,
+    OutputArtifactDeclaration,
+    OutputArtifactDigest,
+    WorkflowProvenance,
+)
+
+OutputArtifactResolver = Callable[
+    [TensorDictBase, tuple[OutputArtifactDeclaration, ...]],
+    tuple[OutputArtifactDigest, ...],
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,17 +74,27 @@ class TDHookWorkflowRunner:
         seed: int | None = None,
         dependencies: Mapping[str, str] | None = None,
         input_artifacts: tuple[InputArtifactReference, ...] = (),
-        output_artifacts: tuple[OutputArtifactReference, ...] = (),
+        output_artifacts: tuple[OutputArtifactDeclaration, ...] = (),
+        output_artifact_resolver: OutputArtifactResolver | None = None,
     ) -> TDHookWorkflowResult:
-        """Execute ``workflow`` and capture versioned plan-to-call provenance."""
+        """Execute ``workflow`` and capture versioned plan-to-call provenance.
+
+        Output identities and roles are declared before execution. Their resolver
+        runs only after successful TDHook execution and returns the digests that
+        are bound to those exact declarations in provenance.
+        """
         self._validate_boundary(workflow, data)
         validated_dependencies = WorkflowProvenance.validate_run_metadata(
             code_revision=code_revision,
             seed=seed,
             dependencies=dependencies,
             input_artifacts=input_artifacts,
-            output_artifacts=output_artifacts,
         )
+        output_artifacts = WorkflowProvenance.validate_output_artifact_declarations(input_artifacts, output_artifacts)
+        if bool(output_artifacts) != (output_artifact_resolver is not None):
+            raise ValueError("output artifact declarations and output_artifact_resolver must be provided together")
+        if output_artifact_resolver is not None and not callable(output_artifact_resolver):
+            raise TypeError("output_artifact_resolver must be callable")
         preflight_plan = workflow.plan(self.interaction.module, data)
         if expected_plan is not None and preflight_plan != expected_plan:
             raise RuntimeError("TDHook workflow plan changed after caller preflight")
@@ -109,6 +129,12 @@ class TDHookWorkflowRunner:
             raise RuntimeError(
                 f"TDHook workflow model-pass mismatch: plan declares {plan.model_passes}, XDRL observed {model_calls}"
             )
+        resolved_output_artifacts = ()
+        if output_artifact_resolver is not None:
+            resolved_output_artifacts = WorkflowProvenance.resolve_output_artifacts(
+                output_artifacts,
+                output_artifact_resolver(result, output_artifacts),
+            )
         provenance = WorkflowProvenance.capture(
             self.interaction.contract,
             plan,
@@ -118,7 +144,7 @@ class TDHookWorkflowRunner:
             seed=seed,
             dependencies=validated_dependencies,
             input_artifacts=input_artifacts,
-            output_artifacts=output_artifacts,
+            output_artifacts=resolved_output_artifacts,
         )
         return TDHookWorkflowResult(result, plan, provenance)
 
@@ -191,4 +217,4 @@ def _reject_unsupported_module(module: torch.nn.Module) -> None:
         raise NotImplementedError("remote modules are not supported by the TDHook workflow runner")
 
 
-__all__ = ["TDHookWorkflowResult", "TDHookWorkflowRunner"]
+__all__ = ["OutputArtifactResolver", "TDHookWorkflowResult", "TDHookWorkflowRunner"]

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -18,7 +18,7 @@ from tdhook.execution import GradientMode
 from tdhook.workflow import Workflow, WorkflowPlan, WorkflowUpdate
 
 from xdrl.interactions import LifecycleEventType, RuntimeInteractionContext
-from xdrl.provenance import WorkflowProvenance
+from xdrl.provenance import InputArtifactReference, OutputArtifactReference, WorkflowProvenance
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,6 +63,8 @@ class TDHookWorkflowRunner:
         expected_plan: WorkflowPlan | None = None,
         seed: int | None = None,
         dependencies: Mapping[str, str] | None = None,
+        input_artifacts: tuple[InputArtifactReference, ...] = (),
+        output_artifacts: tuple[OutputArtifactReference, ...] = (),
     ) -> TDHookWorkflowResult:
         """Execute ``workflow`` and capture versioned plan-to-call provenance."""
         self._validate_boundary(workflow, data)
@@ -70,6 +72,8 @@ class TDHookWorkflowRunner:
             code_revision=code_revision,
             seed=seed,
             dependencies=dependencies,
+            input_artifacts=input_artifacts,
+            output_artifacts=output_artifacts,
         )
         preflight_plan = workflow.plan(self.interaction.module, data)
         if expected_plan is not None and preflight_plan != expected_plan:
@@ -113,6 +117,8 @@ class TDHookWorkflowRunner:
             code_revision=code_revision,
             seed=seed,
             dependencies=validated_dependencies,
+            input_artifacts=input_artifacts,
+            output_artifacts=output_artifacts,
         )
         return TDHookWorkflowResult(result, plan, provenance)
 

--- a/tests/integration/test_artifact_provenance.py
+++ b/tests/integration/test_artifact_provenance.py
@@ -1,4 +1,5 @@
-from dataclasses import FrozenInstanceError
+import hashlib
+from dataclasses import FrozenInstanceError, replace
 
 import pytest
 import torch
@@ -18,7 +19,8 @@ from xdrl import (
     KeyRole,
     KeySchema,
     ModelRole,
-    OutputArtifactReference,
+    OutputArtifactDeclaration,
+    OutputArtifactDigest,
     OutputArtifactRole,
     ProvenanceSchemaError,
     RuntimeInteractionContext,
@@ -32,9 +34,7 @@ def _runner() -> TDHookWorkflowRunner:
     inputs = TensorDictSchema(
         (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))
     )
-    outputs = TensorDictSchema(
-        (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),), BatchSemantics(("env",))
-    )
+    outputs = TensorDictSchema((KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),), BatchSemantics(("env",)))
     contract = InteractionContract(
         "policy:evaluation:artifacts",
         ModelRole.ACTOR,
@@ -69,16 +69,23 @@ def test_workflow_records_typed_input_and_output_artifacts_deterministically() -
         _input("result:paper-reference", InputArtifactRole.REFERENCE_RESULT),
     )
     outputs = (
-        OutputArtifactReference(
+        OutputArtifactDeclaration(
             identity="metrics:run-17",
             role=OutputArtifactRole.METRICS_BUNDLE,
-            digest_algorithm=ArtifactDigestAlgorithm.SHA512,
-            digest_value="b" * 128,
             source="s3://immutable-results/run-17/metrics.json",
             source_is_immutable=True,
             metadata={"format": "json"},
         ),
     )
+    resolved_digests: list[str] = []
+
+    def resolve_outputs(
+        data: TensorDict, declarations: tuple[OutputArtifactDeclaration, ...]
+    ) -> tuple[OutputArtifactDigest, ...]:
+        assert data.get("action") is not None
+        digest = hashlib.sha512(data.get("action").detach().numpy().tobytes()).hexdigest()
+        resolved_digests.append(digest)
+        return (OutputArtifactDigest(declarations[0].identity, ArtifactDigestAlgorithm.SHA512, digest),)
 
     execution = runner.run(
         Workflow(ActivationCaching("module")),
@@ -86,6 +93,7 @@ def test_workflow_records_typed_input_and_output_artifacts_deterministically() -
         code_revision="test-revision",
         input_artifacts=inputs,
         output_artifacts=outputs,
+        output_artifact_resolver=resolve_outputs,
     )
 
     provenance = execution.provenance
@@ -98,7 +106,7 @@ def test_workflow_records_typed_input_and_output_artifacts_deterministically() -
         InputArtifactRole.REFERENCE_RESULT,
     ]
     assert restored.output_artifacts[0].role is OutputArtifactRole.METRICS_BUNDLE
-    assert restored.output_artifacts[0].digest_value == "b" * 128
+    assert restored.output_artifacts[0].digest_value == resolved_digests[0]
 
     with pytest.raises(TypeError):
         restored.input_artifacts[0].metadata["fold"] = 3  # type: ignore[index]
@@ -124,11 +132,9 @@ def test_artifact_references_are_execution_evidence_not_a_reproduction_verdict()
 def test_artifact_validation_fails_before_workflow_execution() -> None:
     runner = _runner()
     duplicate_input = _input("artifact:duplicate", InputArtifactRole.DATASET)
-    duplicate_output = OutputArtifactReference(
+    duplicate_output = OutputArtifactDeclaration(
         identity="artifact:duplicate",
         role=OutputArtifactRole.OTHER,
-        digest_algorithm=ArtifactDigestAlgorithm.SHA256,
-        digest_value="c" * 64,
     )
 
     with pytest.raises(ProvenanceSchemaError, match="artifact identities must be unique"):
@@ -138,10 +144,53 @@ def test_artifact_validation_fails_before_workflow_execution() -> None:
             code_revision="test-revision",
             input_artifacts=(duplicate_input,),
             output_artifacts=(duplicate_output,),
+            output_artifact_resolver=lambda _data, _declarations: (),
         )
 
     assert not runner.interaction.events
-    assert not runner.interaction.module.module._forward_hooks
+
+
+@pytest.mark.integration
+def test_output_artifact_resolver_must_match_declarations_after_execution() -> None:
+    runner = _runner()
+    declaration = OutputArtifactDeclaration("metrics:run-17", OutputArtifactRole.METRICS_BUNDLE)
+
+    with pytest.raises(ProvenanceSchemaError, match="missing identities: metrics:run-17"):
+        runner.run(
+            Workflow(ActivationCaching("module")),
+            runner.interaction.representative_input.clone(),
+            code_revision="test-revision",
+            output_artifacts=(declaration,),
+            output_artifact_resolver=lambda _data, _declarations: (),
+        )
+
+    assert [event.kind.value for event in runner.interaction.events] == ["before", "after"]
+
+
+@pytest.mark.integration
+def test_output_artifact_declaration_requires_a_resolver_before_execution() -> None:
+    runner = _runner()
+    declaration = OutputArtifactDeclaration("metrics:run-17", OutputArtifactRole.METRICS_BUNDLE)
+
+    with pytest.raises(ValueError, match="declarations and output_artifact_resolver must be provided together"):
+        runner.run(
+            Workflow(ActivationCaching("module")),
+            runner.interaction.representative_input.clone(),
+            code_revision="test-revision",
+            output_artifacts=(declaration,),
+        )
+
+    assert not runner.interaction.events
+
+
+@pytest.mark.integration
+def test_artifact_reference_can_be_replaced_after_metadata_is_frozen() -> None:
+    original = _input("dataset:evaluation", InputArtifactRole.DATASET)
+
+    updated = replace(original, identity="dataset:evaluation-v2")
+
+    assert updated.metadata == original.metadata
+    assert updated.identity == "dataset:evaluation-v2"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_artifact_provenance.py
+++ b/tests/integration/test_artifact_provenance.py
@@ -21,6 +21,7 @@ from xdrl import (
     ModelRole,
     OutputArtifactDeclaration,
     OutputArtifactDigest,
+    OutputArtifactReference,
     OutputArtifactRole,
     ProvenanceSchemaError,
     RuntimeInteractionContext,
@@ -58,6 +59,17 @@ def _input(identity: str, role: InputArtifactRole) -> InputArtifactReference:
         revision="0123456789abcdef",
         metadata={"license": "research-only", "fold": 2},
     )
+
+
+def _dependencies() -> dict[str, str]:
+    return {
+        "python": "3.12.0",
+        "torch": "2.13.0",
+        "tensordict": "0.13.0",
+        "torchrl": "0.13.0",
+        "tdhook": "0.2.0",
+        "xdrl": "0.2.0",
+    }
 
 
 @pytest.mark.integration
@@ -181,6 +193,112 @@ def test_output_artifact_declaration_requires_a_resolver_before_execution() -> N
         )
 
     assert not runner.interaction.events
+
+
+@pytest.mark.integration
+def test_output_artifact_resolver_must_be_callable_before_execution() -> None:
+    runner = _runner()
+    declaration = OutputArtifactDeclaration("metrics:run-17", OutputArtifactRole.METRICS_BUNDLE)
+
+    with pytest.raises(TypeError, match="output_artifact_resolver must be callable"):
+        runner.run(
+            Workflow(ActivationCaching("module")),
+            runner.interaction.representative_input.clone(),
+            code_revision="test-revision",
+            output_artifacts=(declaration,),
+            output_artifact_resolver=object(),  # type: ignore[arg-type]
+        )
+
+    assert not runner.interaction.events
+
+
+@pytest.mark.integration
+def test_output_artifact_resolution_rejects_mismatched_duplicate_and_untyped_digests() -> None:
+    declaration = OutputArtifactDeclaration("metrics:run-17", OutputArtifactRole.METRICS_BUNDLE)
+    digest = OutputArtifactDigest("metrics:other", ArtifactDigestAlgorithm.SHA256, "e" * 64)
+    with pytest.raises(ProvenanceSchemaError, match="digest identity must match its declaration"):
+        declaration.resolve(digest)
+
+    with pytest.raises(ProvenanceSchemaError, match="must return OutputArtifactDigest values"):
+        WorkflowProvenance.resolve_output_artifacts((declaration,), (object(),))  # type: ignore[arg-type]
+
+    duplicate = OutputArtifactDigest("metrics:run-17", ArtifactDigestAlgorithm.SHA256, "e" * 64)
+    with pytest.raises(ProvenanceSchemaError, match="returned duplicate identities"):
+        WorkflowProvenance.resolve_output_artifacts((declaration,), (duplicate, duplicate))
+
+    with pytest.raises(ProvenanceSchemaError, match="unknown identities: metrics:other"):
+        WorkflowProvenance.resolve_output_artifacts((declaration,), (digest,))
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"role": InputArtifactRole.OTHER}, "role must be a OutputArtifactRole"),
+        ({"source_is_immutable": "yes"}, "source_is_immutable must be a boolean"),
+        ({"revision": "v1"}, "revision requires source"),
+        ({"source_is_immutable": True}, "source_is_immutable requires source"),
+    ],
+)
+def test_output_artifact_declaration_rejects_invalid_location_fields(changes: dict[str, object], message: str) -> None:
+    values: dict[str, object] = {
+        "identity": "metrics:run-17",
+        "role": OutputArtifactRole.METRICS_BUNDLE,
+    }
+    values.update(changes)
+
+    with pytest.raises(ProvenanceSchemaError, match=message):
+        OutputArtifactDeclaration(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.integration
+def test_output_artifact_digest_requires_a_typed_algorithm() -> None:
+    with pytest.raises(ProvenanceSchemaError, match="digest_algorithm must be an ArtifactDigestAlgorithm"):
+        OutputArtifactDigest("metrics:run-17", "sha256", "e" * 64)  # type: ignore[arg-type]
+
+
+@pytest.mark.integration
+def test_artifact_reference_decoder_rejects_unknown_roles_and_algorithms() -> None:
+    payload = _input("dataset:evaluation", InputArtifactRole.DATASET).to_dict()
+    payload["role"] = "invented"
+    with pytest.raises(ProvenanceSchemaError, match="role must be a known string value"):
+        InputArtifactReference.from_dict(payload)
+
+    payload = _input("dataset:evaluation", InputArtifactRole.DATASET).to_dict()
+    payload["digest_algorithm"] = "md5"
+    with pytest.raises(ProvenanceSchemaError, match="digest_algorithm must be a known string value"):
+        InputArtifactReference.from_dict(payload)
+
+
+@pytest.mark.integration
+def test_run_metadata_rejects_untyped_and_duplicate_artifact_references() -> None:
+    kwargs = {"code_revision": "test-revision", "dependencies": _dependencies()}
+    with pytest.raises(ProvenanceSchemaError, match="input_artifacts must contain only"):
+        WorkflowProvenance.validate_run_metadata(**kwargs, input_artifacts=(object(),))  # type: ignore[arg-type]
+    with pytest.raises(ProvenanceSchemaError, match="output_artifacts must contain only"):
+        WorkflowProvenance.validate_run_metadata(**kwargs, output_artifacts=(object(),))  # type: ignore[arg-type]
+
+    input_reference = _input("artifact:duplicate", InputArtifactRole.DATASET)
+    output_reference = OutputArtifactReference(
+        "artifact:duplicate",
+        OutputArtifactRole.OTHER,
+        ArtifactDigestAlgorithm.SHA256,
+        "f" * 64,
+    )
+    with pytest.raises(ProvenanceSchemaError, match="artifact identities must be unique"):
+        WorkflowProvenance.validate_run_metadata(
+            **kwargs,
+            input_artifacts=(input_reference,),
+            output_artifacts=(output_reference,),
+        )
+
+
+@pytest.mark.integration
+def test_output_declaration_validation_rejects_untyped_collections() -> None:
+    with pytest.raises(ProvenanceSchemaError, match="output_artifacts must contain only"):
+        WorkflowProvenance.validate_output_artifact_declarations((), (object(),))  # type: ignore[arg-type]
+    with pytest.raises(ProvenanceSchemaError, match="input_artifacts must contain only"):
+        WorkflowProvenance.validate_output_artifact_declarations((object(),), ())  # type: ignore[arg-type]
 
 
 @pytest.mark.integration

--- a/tests/integration/test_artifact_provenance.py
+++ b/tests/integration/test_artifact_provenance.py
@@ -1,0 +1,205 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from tdhook.latent import ActivationCaching
+from tdhook.workflow import Workflow
+
+from xdrl import (
+    ArtifactDigestAlgorithm,
+    BatchSemantics,
+    InputArtifactReference,
+    InputArtifactRole,
+    InteractionContract,
+    InteractionPhase,
+    KeyPresence,
+    KeyRole,
+    KeySchema,
+    ModelRole,
+    OutputArtifactReference,
+    OutputArtifactRole,
+    ProvenanceSchemaError,
+    RuntimeInteractionContext,
+    TDHookWorkflowRunner,
+    TensorDictSchema,
+    WorkflowProvenance,
+)
+
+
+def _runner() -> TDHookWorkflowRunner:
+    inputs = TensorDictSchema(
+        (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),), BatchSemantics(("env",))
+    )
+    outputs = TensorDictSchema(
+        (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),), BatchSemantics(("env",))
+    )
+    contract = InteractionContract(
+        "policy:evaluation:artifacts",
+        ModelRole.ACTOR,
+        InteractionPhase.EVALUATION,
+        "policy",
+        inputs,
+        outputs,
+    )
+    policy = TensorDictModule(torch.nn.Linear(2, 1), in_keys=["observation"], out_keys=["action"])
+    batch = TensorDict({"observation": torch.ones(2, 2)}, batch_size=[2])
+    return TDHookWorkflowRunner(RuntimeInteractionContext(contract, policy, batch))
+
+
+def _input(identity: str, role: InputArtifactRole) -> InputArtifactReference:
+    return InputArtifactReference(
+        identity=identity,
+        role=role,
+        digest_algorithm=ArtifactDigestAlgorithm.SHA256,
+        digest_value="a" * 64,
+        source="https://example.invalid/research-assets.git",
+        revision="0123456789abcdef",
+        metadata={"license": "research-only", "fold": 2},
+    )
+
+
+@pytest.mark.integration
+def test_workflow_records_typed_input_and_output_artifacts_deterministically() -> None:
+    runner = _runner()
+    inputs = (
+        _input("checkpoint:policy-v1", InputArtifactRole.MODEL_CHECKPOINT),
+        _input("split:evaluation-v2", InputArtifactRole.EVALUATION_SPLIT),
+        _input("result:paper-reference", InputArtifactRole.REFERENCE_RESULT),
+    )
+    outputs = (
+        OutputArtifactReference(
+            identity="metrics:run-17",
+            role=OutputArtifactRole.METRICS_BUNDLE,
+            digest_algorithm=ArtifactDigestAlgorithm.SHA512,
+            digest_value="b" * 128,
+            source="s3://immutable-results/run-17/metrics.json",
+            source_is_immutable=True,
+            metadata={"format": "json"},
+        ),
+    )
+
+    execution = runner.run(
+        Workflow(ActivationCaching("module")),
+        runner.interaction.representative_input.clone(),
+        code_revision="test-revision",
+        input_artifacts=inputs,
+        output_artifacts=outputs,
+    )
+
+    provenance = execution.provenance
+    restored = WorkflowProvenance.from_json(provenance.to_json())
+    assert restored == provenance
+    assert restored.to_json() == provenance.to_json()
+    assert [item.role for item in restored.input_artifacts] == [
+        InputArtifactRole.MODEL_CHECKPOINT,
+        InputArtifactRole.EVALUATION_SPLIT,
+        InputArtifactRole.REFERENCE_RESULT,
+    ]
+    assert restored.output_artifacts[0].role is OutputArtifactRole.METRICS_BUNDLE
+    assert restored.output_artifacts[0].digest_value == "b" * 128
+
+    with pytest.raises(TypeError):
+        restored.input_artifacts[0].metadata["fold"] = 3  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        restored.output_artifacts[0].identity = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.integration
+def test_artifact_references_are_execution_evidence_not_a_reproduction_verdict() -> None:
+    runner = _runner()
+    execution = runner.run(
+        Workflow(ActivationCaching("module")),
+        runner.interaction.representative_input.clone(),
+        code_revision="test-revision",
+        input_artifacts=(_input("result:paper-reference", InputArtifactRole.REFERENCE_RESULT),),
+    )
+
+    assert execution.provenance.input_artifacts[0].role is InputArtifactRole.REFERENCE_RESULT
+    assert not hasattr(execution.provenance, "result_reproduced")
+
+
+@pytest.mark.integration
+def test_artifact_validation_fails_before_workflow_execution() -> None:
+    runner = _runner()
+    duplicate_input = _input("artifact:duplicate", InputArtifactRole.DATASET)
+    duplicate_output = OutputArtifactReference(
+        identity="artifact:duplicate",
+        role=OutputArtifactRole.OTHER,
+        digest_algorithm=ArtifactDigestAlgorithm.SHA256,
+        digest_value="c" * 64,
+    )
+
+    with pytest.raises(ProvenanceSchemaError, match="artifact identities must be unique"):
+        runner.run(
+            Workflow(ActivationCaching("module")),
+            runner.interaction.representative_input.clone(),
+            code_revision="test-revision",
+            input_artifacts=(duplicate_input,),
+            output_artifacts=(duplicate_output,),
+        )
+
+    assert not runner.interaction.events
+    assert not runner.interaction.module.module._forward_hooks
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"identity": ""}, "identity must be a non-empty string"),
+        ({"digest_value": "ABC"}, "digest_value must be 64 lowercase hexadecimal characters"),
+        (
+            {"source": "https://example.invalid/assets/main", "revision": None},
+            "source requires a revision unless it is explicitly immutable",
+        ),
+        ({"metadata": {"callback": object()}}, "metadata must contain only JSON-compatible values"),
+    ],
+)
+def test_input_artifact_reference_rejects_malformed_evidence(kwargs: dict[str, object], message: str) -> None:
+    values: dict[str, object] = {
+        "identity": "dataset:evaluation",
+        "role": InputArtifactRole.DATASET,
+        "digest_algorithm": ArtifactDigestAlgorithm.SHA256,
+        "digest_value": "d" * 64,
+    }
+    values.update(kwargs)
+
+    with pytest.raises(ProvenanceSchemaError, match=message):
+        InputArtifactReference(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.integration
+def test_provenance_explicitly_rejects_revision_two_without_implicit_migration() -> None:
+    runner = _runner()
+    provenance = runner.run(
+        Workflow(ActivationCaching("module")),
+        runner.interaction.representative_input.clone(),
+        code_revision="test-revision",
+    ).provenance
+    payload = provenance.to_dict()
+    payload["schema_revision"] = 2
+    del payload["input_artifacts"]
+    del payload["output_artifacts"]
+
+    with pytest.raises(ProvenanceSchemaError, match="cannot be migrated without caller-supplied artifact identities"):
+        WorkflowProvenance.from_dict(payload)
+
+
+@pytest.mark.integration
+def test_artifact_decoder_rejects_unknown_fields_and_non_array_collections() -> None:
+    reference = _input("dataset:evaluation", InputArtifactRole.DATASET).to_dict()
+    reference["invented"] = True
+    with pytest.raises(ProvenanceSchemaError, match="missing or unknown fields"):
+        InputArtifactReference.from_dict(reference)
+
+    runner = _runner()
+    payload = runner.run(
+        Workflow(ActivationCaching("module")),
+        runner.interaction.representative_input.clone(),
+        code_revision="test-revision",
+    ).provenance.to_dict()
+    payload["input_artifacts"] = {}
+    with pytest.raises(ProvenanceSchemaError, match="input_artifacts must be an array"):
+        WorkflowProvenance.from_dict(payload)


### PR DESCRIPTION
## Summary

- add immutable, tensor-free input and output artifact references with typed roles and cryptographic digests
- declare output identities before execution, then bind digests resolved from the completed TDHook result
- capture references in schema-revision-3 `WorkflowProvenance` with strict identity, digest, source, and metadata validation
- explicitly reject implicit migration of revision-2 provenance because missing artifact identities cannot be reconstructed
- keep artifact references as execution evidence, without representing them as proof of reproduced results

## Validation

- CI run #134 — successful on Python 3.11, 3.12, and 3.13
- `uv run pre-commit run --all-files`
- `just tests`
- `just docs`

Closes #53