### PR TITLE
Run matched TDHook workflow pairs with XDRL provenance

### DIFF
--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -67,7 +67,17 @@ from xdrl.provenance import (
     WorkflowPlanEvidence,
     WorkflowProvenance,
 )
-from xdrl.tdhook import OutputArtifactResolver, TDHookWorkflowResult, TDHookWorkflowRunner
+from xdrl.tdhook import (
+    OutputArtifactResolver,
+    PairedWorkflowExecutionError,
+    PairedWorkflowValidationError,
+    TDHookPairedWorkflowResult,
+    TDHookWorkflowPairManifest,
+    TDHookWorkflowResult,
+    TDHookWorkflowRunner,
+    WorkflowArmReference,
+    WorkflowStepDifference,
+)
 from xdrl.types import (
     BatchSemantics,
     ContractModule,
@@ -126,6 +136,8 @@ __all__ = [
     "PRIVATE_UPSTREAM_APIS",
     "PrivateAPIUsage",
     "ProvenanceSchemaError",
+    "PairedWorkflowExecutionError",
+    "PairedWorkflowValidationError",
     "DimensionReduction",
     "ReductionKind",
     "RecurrentCollectorMode",
@@ -142,6 +154,8 @@ __all__ = [
     "SupportLevel",
     "PairedInterventionResult",
     "TDHookWorkflowResult",
+    "TDHookPairedWorkflowResult",
+    "TDHookWorkflowPairManifest",
     "TDHookWorkflowRunner",
     "TensorDictSchema",
     "TensorDictKey",
@@ -150,9 +164,11 @@ __all__ = [
     "VersionRequirement",
     "WORKFLOW_PROVENANCE_SCHEMA_REVISION",
     "WorkflowCompatibilityEvidence",
+    "WorkflowArmReference",
     "WorkflowExecutionEvidence",
     "WorkflowPlanEvidence",
     "WorkflowProvenance",
+    "WorkflowStepDifference",
     "WORKFLOW_CONFORMANCE",
     "installed_dependency_revisions",
     "installed_dependency_versions",

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -176,8 +176,8 @@ class TDHookWorkflowPairManifest:
             arms.append(
                 WorkflowArmReference(
                     provenance_sha256=arm["provenance_sha256"],
-                    input_artifacts=tuple(arm["input_artifacts"]),
-                    output_artifacts=tuple(arm["output_artifacts"]),
+                    input_artifacts=_decoded_string_array(arm["input_artifacts"], f"{name}.input_artifacts"),
+                    output_artifacts=_decoded_string_array(arm["output_artifacts"], f"{name}.output_artifacts"),
                 )
             )
         return cls(
@@ -189,8 +189,10 @@ class TDHookWorkflowPairManifest:
             changed_steps=tuple(WorkflowStepDifference(**item) for item in changed_steps),
             baseline=arms[0],
             intervention=arms[1],
-            matched_rng_sources=tuple(payload["matched_rng_sources"]),
-            unsupported_randomness_sources=tuple(payload["unsupported_randomness_sources"]),
+            matched_rng_sources=_decoded_string_array(payload["matched_rng_sources"], "matched_rng_sources"),
+            unsupported_randomness_sources=_decoded_string_array(
+                payload["unsupported_randomness_sources"], "unsupported_randomness_sources"
+            ),
             interpretation=payload["interpretation"],
         )
 
@@ -393,7 +395,10 @@ class TDHookWorkflowRunner:
 
         initial_rng = _rng_state()
         final_rng = initial_rng
-        module_state = _ModuleStateSnapshot.capture(self.interaction.module)
+        module_states = tuple(
+            (module, _ModuleStateSnapshot.capture(module))
+            for module in _paired_state_modules(self.interaction.module, baseline_workflow, intervention_workflow)
+        )
         baseline: TDHookWorkflowResult | None = None
         arm = "baseline"
         try:
@@ -410,7 +415,7 @@ class TDHookWorkflowRunner:
                 callback_identifiers=callback_identifiers,
             )
             final_rng = _rng_state()
-            module_state.restore(self.interaction.module)
+            _restore_module_states(module_states)
             _set_rng_state(initial_rng)
             arm = "intervention"
             intervention = other.run(
@@ -428,7 +433,7 @@ class TDHookWorkflowRunner:
         except Exception as error:
             raise PairedWorkflowExecutionError(arm, baseline=baseline) from error
         finally:
-            module_state.restore(self.interaction.module)
+            _restore_module_states(module_states)
             _set_rng_state(final_rng)
 
         manifest = TDHookWorkflowPairManifest(
@@ -507,6 +512,12 @@ def _configured_step_description(description: object) -> str:
         return json.dumps(to_dict(), sort_keys=True, separators=(",", ":"), allow_nan=False)
     except (TypeError, ValueError) as error:
         raise TypeError("TDHook configured-step description must be JSON-compatible") from error
+
+
+def _decoded_string_array(value: object, field: str) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(f"{field} must be an array")
+    return tuple(value)
 
 
 def _workflow_descriptions(
@@ -606,11 +617,14 @@ def _validate_pair_contract(
         raise PairedWorkflowValidationError("paired workflows require identical interaction contracts")
     if baseline.interaction.module is not intervention.interaction.module:
         raise PairedWorkflowValidationError("paired workflows must execute against the same module instance")
+    if baseline.interaction is not intervention.interaction:
+        raise PairedWorkflowValidationError("paired workflows require the same runtime interaction context")
 
 
 @dataclass(frozen=True, slots=True)
 class _ModuleStateSnapshot:
     state: Mapping[str, torch.Tensor]
+    buffers: Mapping[str, torch.Tensor]
     training: tuple[bool, ...]
     gradients: tuple[torch.Tensor | None, ...]
 
@@ -618,6 +632,7 @@ class _ModuleStateSnapshot:
     def capture(cls, module: torch.nn.Module) -> _ModuleStateSnapshot:
         return cls(
             {name: value.detach().clone() for name, value in module.state_dict().items()},
+            {name: value.detach().clone() for name, value in module.named_buffers()},
             tuple(child.training for child in module.modules()),
             tuple(
                 parameter.grad.detach().clone() if parameter.grad is not None else None
@@ -627,6 +642,12 @@ class _ModuleStateSnapshot:
 
     def restore(self, module: torch.nn.Module) -> None:
         module.load_state_dict(self.state, strict=True)
+        current_buffers = dict(module.named_buffers())
+        if set(current_buffers) != set(self.buffers):
+            raise RuntimeError("paired workflow changed the module buffer structure")
+        with torch.no_grad():
+            for name, value in self.buffers.items():
+                current_buffers[name].copy_(value)
         children = tuple(module.modules())
         if len(children) != len(self.training):
             raise RuntimeError("paired workflow changed the module hierarchy")
@@ -637,6 +658,25 @@ class _ModuleStateSnapshot:
             raise RuntimeError("paired workflow changed the module parameter structure")
         for parameter, gradient in zip(parameters, self.gradients, strict=True):
             parameter.grad = gradient.detach().clone() if gradient is not None else None
+
+
+def _paired_state_modules(
+    interaction_module: torch.nn.Module,
+    baseline: Workflow,
+    intervention: Workflow,
+) -> tuple[torch.nn.Module, ...]:
+    modules = [interaction_module]
+    for workflow in (baseline, intervention):
+        for wrapped_step in workflow.steps:
+            step = wrapped_step.step if isinstance(wrapped_step, WorkflowUpdate) else wrapped_step
+            if isinstance(step, TensorDictModuleBase) and all(step is not existing for existing in modules):
+                modules.append(step)
+    return tuple(modules)
+
+
+def _restore_module_states(states: tuple[tuple[torch.nn.Module, _ModuleStateSnapshot], ...]) -> None:
+    for module, snapshot in reversed(states):
+        snapshot.restore(module)
 
 
 def _rng_state() -> tuple[torch.Tensor, list[torch.Tensor] | None]:

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -8,8 +8,11 @@ plan-to-call-count evidence around every actual root model call.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from typing import Any
 
 import torch
 from tensordict import TensorDictBase
@@ -38,6 +41,193 @@ class TDHookWorkflowResult:
     data: TensorDictBase
     plan: WorkflowPlan
     provenance: WorkflowProvenance
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowStepDifference:
+    """One declared configured-step difference between paired workflow arms."""
+
+    index: int
+    baseline: str | None
+    intervention: str | None
+
+    def __post_init__(self) -> None:
+        if type(self.index) is not int or self.index < 0:
+            raise ValueError("workflow step difference index must be a non-negative integer")
+        if self.baseline == self.intervention:
+            raise ValueError("workflow step difference must contain distinct arm descriptions")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowArmReference:
+    """Tensor-free references to one paired arm's durable evidence."""
+
+    provenance_sha256: str
+    input_artifacts: tuple[str, ...]
+    output_artifacts: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.provenance_sha256) != 64 or any(
+            character not in "0123456789abcdef" for character in self.provenance_sha256
+        ):
+            raise ValueError("paired arm provenance_sha256 must be a lowercase SHA-256 digest")
+        for values, field in (
+            (self.input_artifacts, "input_artifacts"),
+            (self.output_artifacts, "output_artifacts"),
+        ):
+            if not isinstance(values, tuple) or any(not isinstance(value, str) or not value for value in values):
+                raise TypeError(f"paired arm {field} must be a tuple of non-empty strings")
+            if len(values) != len(set(values)):
+                raise ValueError(f"paired arm {field} identities must be unique")
+
+
+@dataclass(frozen=True, slots=True)
+class TDHookWorkflowPairManifest:
+    """Tensor-free evidence that two TDHook workflow arms were matched.
+
+    The manifest records execution mechanics and provenance references only. It
+    deliberately makes no claim that a difference between outputs is causal.
+    """
+
+    schema_revision: int
+    pair_id: str
+    interaction_id: str
+    model_id: str
+    checkpoint_id: str
+    changed_steps: tuple[WorkflowStepDifference, ...]
+    baseline: WorkflowArmReference
+    intervention: WorkflowArmReference
+    matched_rng_sources: tuple[str, ...]
+    unsupported_randomness_sources: tuple[str, ...]
+    interpretation: str = "mechanics_and_provenance_only"
+
+    def __post_init__(self) -> None:
+        if self.schema_revision != 1:
+            raise ValueError("unsupported paired workflow manifest schema revision")
+        for value, field in (
+            (self.pair_id, "pair_id"),
+            (self.interaction_id, "interaction_id"),
+            (self.model_id, "model_id"),
+            (self.checkpoint_id, "checkpoint_id"),
+        ):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{field} must be a non-empty string")
+        if tuple(item.index for item in self.changed_steps) != tuple(
+            sorted({item.index for item in self.changed_steps})
+        ):
+            raise ValueError("paired workflow changed step indices must be unique and sorted")
+        if not all(isinstance(item, WorkflowStepDifference) for item in self.changed_steps):
+            raise TypeError("changed_steps must contain WorkflowStepDifference values")
+        if not isinstance(self.baseline, WorkflowArmReference) or not isinstance(
+            self.intervention, WorkflowArmReference
+        ):
+            raise TypeError("paired workflow arms must be WorkflowArmReference values")
+        for sources, field in (
+            (self.matched_rng_sources, "matched_rng_sources"),
+            (self.unsupported_randomness_sources, "unsupported_randomness_sources"),
+        ):
+            if not isinstance(sources, tuple) or any(not isinstance(source, str) or not source for source in sources):
+                raise TypeError(f"{field} must be a tuple of non-empty strings")
+            if len(sources) != len(set(sources)):
+                raise ValueError(f"{field} must contain unique values")
+        if self.interpretation != "mechanics_and_provenance_only":
+            raise ValueError("paired workflow manifests cannot assign a causal interpretation")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a detached JSON-compatible representation."""
+        return asdict(self)
+
+    def to_json(self) -> str:
+        """Encode the pair manifest deterministically."""
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> TDHookWorkflowPairManifest:
+        """Decode one versioned pair manifest without reconstructing tensors."""
+        if not isinstance(payload, Mapping):
+            raise TypeError("paired workflow manifest must be an object")
+        expected = {
+            "schema_revision",
+            "pair_id",
+            "interaction_id",
+            "model_id",
+            "checkpoint_id",
+            "changed_steps",
+            "baseline",
+            "intervention",
+            "matched_rng_sources",
+            "unsupported_randomness_sources",
+            "interpretation",
+        }
+        if set(payload) != expected:
+            raise ValueError("paired workflow manifest has missing or unknown fields")
+        changed_steps = payload["changed_steps"]
+        if not isinstance(changed_steps, (list, tuple)):
+            raise TypeError("changed_steps must be an array")
+        arms = []
+        for name in ("baseline", "intervention"):
+            arm = payload[name]
+            if not isinstance(arm, Mapping) or set(arm) != {
+                "provenance_sha256",
+                "input_artifacts",
+                "output_artifacts",
+            }:
+                raise ValueError(f"{name} arm reference has missing or unknown fields")
+            arms.append(
+                WorkflowArmReference(
+                    provenance_sha256=arm["provenance_sha256"],
+                    input_artifacts=tuple(arm["input_artifacts"]),
+                    output_artifacts=tuple(arm["output_artifacts"]),
+                )
+            )
+        return cls(
+            schema_revision=payload["schema_revision"],
+            pair_id=payload["pair_id"],
+            interaction_id=payload["interaction_id"],
+            model_id=payload["model_id"],
+            checkpoint_id=payload["checkpoint_id"],
+            changed_steps=tuple(WorkflowStepDifference(**item) for item in changed_steps),
+            baseline=arms[0],
+            intervention=arms[1],
+            matched_rng_sources=tuple(payload["matched_rng_sources"]),
+            unsupported_randomness_sources=tuple(payload["unsupported_randomness_sources"]),
+            interpretation=payload["interpretation"],
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> TDHookWorkflowPairManifest:
+        """Decode one JSON pair manifest."""
+        value = json.loads(payload)
+        if not isinstance(value, dict):
+            raise TypeError("paired workflow manifest JSON must contain an object")
+        return cls.from_dict(value)
+
+
+@dataclass(frozen=True, slots=True)
+class TDHookPairedWorkflowResult:
+    """Native results for both arms plus their tensor-free pair manifest."""
+
+    baseline: TDHookWorkflowResult
+    intervention: TDHookWorkflowResult
+    manifest: TDHookWorkflowPairManifest
+
+
+class PairedWorkflowValidationError(ValueError):
+    """Two workflow arms cannot be compared under the declared pair contract."""
+
+
+class PairedWorkflowExecutionError(RuntimeError):
+    """One paired arm failed after pair validation and state preflight."""
+
+    def __init__(
+        self,
+        arm: str,
+        *,
+        baseline: TDHookWorkflowResult | None = None,
+    ) -> None:
+        super().__init__(f"paired TDHook workflow {arm} arm failed")
+        self.arm = arm
+        self.baseline = baseline
 
 
 @dataclass(slots=True)
@@ -76,6 +266,7 @@ class TDHookWorkflowRunner:
         input_artifacts: tuple[InputArtifactReference, ...] = (),
         output_artifacts: tuple[OutputArtifactDeclaration, ...] = (),
         output_artifact_resolver: OutputArtifactResolver | None = None,
+        callback_identifiers: Mapping[Callable[..., object], str] | None = None,
     ) -> TDHookWorkflowResult:
         """Execute ``workflow`` and capture versioned plan-to-call provenance.
 
@@ -112,7 +303,12 @@ class TDHookWorkflowRunner:
                 "TDHookWorkflowRunner requires TDHook public execution evidence; install the supported TDHook revision"
             )
         configured_steps = tuple(
-            _configured_step_description(description) for description in describe(self.interaction.module, data)
+            _configured_step_description(description)
+            for description in describe(
+                self.interaction.module,
+                data,
+                callback_identifiers=callback_identifiers,
+            )
         )
         event_start = len(self.interaction.events)
         with self.interaction, self.interaction.observe_module_calls():
@@ -147,6 +343,112 @@ class TDHookWorkflowRunner:
             output_artifacts=resolved_output_artifacts,
         )
         return TDHookWorkflowResult(result, plan, provenance)
+
+    def run_paired(
+        self,
+        baseline_workflow: Workflow,
+        intervention_workflow: Workflow,
+        data: TensorDictBase,
+        *,
+        pair_id: str,
+        code_revision: str,
+        declared_workflow_differences: tuple[int, ...] = (),
+        intervention_runner: TDHookWorkflowRunner | None = None,
+        expected_baseline_plan: WorkflowPlan | None = None,
+        expected_intervention_plan: WorkflowPlan | None = None,
+        seed: int | None = None,
+        dependencies: Mapping[str, str] | None = None,
+        input_artifacts: tuple[InputArtifactReference, ...] = (),
+        baseline_output_artifacts: tuple[OutputArtifactDeclaration, ...] = (),
+        baseline_output_artifact_resolver: OutputArtifactResolver | None = None,
+        intervention_output_artifacts: tuple[OutputArtifactDeclaration, ...] = (),
+        intervention_output_artifact_resolver: OutputArtifactResolver | None = None,
+        callback_identifiers: Mapping[Callable[..., object], str] | None = None,
+    ) -> TDHookPairedWorkflowResult:
+        """Run matched baseline and intervention workflows without state leakage.
+
+        Only the process-global PyTorch CPU generator and, when available, all
+        process-global CUDA generators are matched. Python, NumPy, application
+        generators, and other external randomness sources remain caller-owned
+        and are declared as unsupported in the returned manifest.
+        """
+        other = self if intervention_runner is None else intervention_runner
+        _validate_pair_contract(self, other, pair_id)
+        self._validate_boundary(baseline_workflow, data)
+        other._validate_boundary(intervention_workflow, data)
+        _validate_paired_operators(baseline_workflow, intervention_workflow)
+        baseline_steps = _workflow_descriptions(
+            baseline_workflow, self.interaction.module, data, callback_identifiers=callback_identifiers
+        )
+        intervention_steps = _workflow_descriptions(
+            intervention_workflow, other.interaction.module, data, callback_identifiers=callback_identifiers
+        )
+        differences = _workflow_differences(baseline_steps, intervention_steps)
+        declared = _declared_difference_indices(declared_workflow_differences)
+        actual = tuple(item.index for item in differences)
+        if actual != declared:
+            raise PairedWorkflowValidationError(
+                f"workflow differences do not match declaration: declared {declared!r}, observed {actual!r}"
+            )
+
+        initial_rng = _rng_state()
+        final_rng = initial_rng
+        module_state = _ModuleStateSnapshot.capture(self.interaction.module)
+        baseline: TDHookWorkflowResult | None = None
+        arm = "baseline"
+        try:
+            baseline = self.run(
+                baseline_workflow,
+                data.clone(),
+                code_revision=code_revision,
+                expected_plan=expected_baseline_plan,
+                seed=seed,
+                dependencies=dependencies,
+                input_artifacts=input_artifacts,
+                output_artifacts=baseline_output_artifacts,
+                output_artifact_resolver=baseline_output_artifact_resolver,
+                callback_identifiers=callback_identifiers,
+            )
+            final_rng = _rng_state()
+            module_state.restore(self.interaction.module)
+            _set_rng_state(initial_rng)
+            arm = "intervention"
+            intervention = other.run(
+                intervention_workflow,
+                data.clone(),
+                code_revision=code_revision,
+                expected_plan=expected_intervention_plan,
+                seed=seed,
+                dependencies=dependencies,
+                input_artifacts=input_artifacts,
+                output_artifacts=intervention_output_artifacts,
+                output_artifact_resolver=intervention_output_artifact_resolver,
+                callback_identifiers=callback_identifiers,
+            )
+        except Exception as error:
+            raise PairedWorkflowExecutionError(arm, baseline=baseline) from error
+        finally:
+            module_state.restore(self.interaction.module)
+            _set_rng_state(final_rng)
+
+        manifest = TDHookWorkflowPairManifest(
+            schema_revision=1,
+            pair_id=pair_id,
+            interaction_id=self.interaction.contract.identity,
+            model_id=self.interaction.contract.model_id or "",
+            checkpoint_id=self.interaction.contract.checkpoint_id or "",
+            changed_steps=differences,
+            baseline=_arm_reference(baseline),
+            intervention=_arm_reference(intervention),
+            matched_rng_sources=("torch_cpu",) + (("torch_cuda",) if initial_rng[1] is not None else ()),
+            unsupported_randomness_sources=(
+                "python_random",
+                "numpy_random",
+                "explicit_torch_generators",
+                "external_or_application_randomness",
+            ),
+        )
+        return TDHookPairedWorkflowResult(baseline, intervention, manifest)
 
     def _validate_boundary(self, workflow: Workflow, data: TensorDictBase) -> None:
         if not isinstance(workflow, Workflow):
@@ -207,6 +509,157 @@ def _configured_step_description(description: object) -> str:
         raise TypeError("TDHook configured-step description must be JSON-compatible") from error
 
 
+def _workflow_descriptions(
+    workflow: Workflow,
+    module: torch.nn.Module,
+    data: TensorDictBase,
+    *,
+    callback_identifiers: Mapping[Callable[..., object], str] | None,
+) -> tuple[str, ...]:
+    try:
+        descriptions = workflow.describe(module, data, callback_identifiers=callback_identifiers)
+    except AttributeError as error:
+        raise RuntimeError(
+            "TDHookWorkflowRunner requires TDHook public execution evidence; install the supported TDHook revision"
+        ) from error
+    configured = iter(descriptions)
+    results = []
+    for wrapped_step in workflow.steps:
+        step = wrapped_step.step if isinstance(wrapped_step, WorkflowUpdate) else wrapped_step
+        if isinstance(step, TensorDictModuleBase):
+            continue
+        description = _configured_step_description(next(configured))
+        results.append(
+            json.dumps(
+                {
+                    "allow_output_overwrite": isinstance(wrapped_step, WorkflowUpdate),
+                    "description": json.loads(description),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        )
+    try:
+        next(configured)
+    except StopIteration:
+        return tuple(results)
+    raise RuntimeError("TDHook workflow descriptions do not match configured method steps")
+
+
+def _validate_paired_operators(baseline: Workflow, intervention: Workflow) -> None:
+    """Require non-method operators to be literally shared between both arms."""
+    size = max(len(baseline.steps), len(intervention.steps))
+    for index in range(size):
+        left = baseline.steps[index] if index < len(baseline.steps) else None
+        right = intervention.steps[index] if index < len(intervention.steps) else None
+        left_step = left.step if isinstance(left, WorkflowUpdate) else left
+        right_step = right.step if isinstance(right, WorkflowUpdate) else right
+        if isinstance(left_step, TensorDictModuleBase) or isinstance(right_step, TensorDictModuleBase):
+            if left_step is not right_step or isinstance(left, WorkflowUpdate) is not isinstance(
+                right, WorkflowUpdate
+            ):
+                raise PairedWorkflowValidationError(
+                    "paired workflow TensorDict operators must be the same instances at the same indices"
+                )
+
+
+def _workflow_differences(
+    baseline: tuple[str, ...], intervention: tuple[str, ...]
+) -> tuple[WorkflowStepDifference, ...]:
+    return tuple(
+        WorkflowStepDifference(
+            index,
+            baseline[index] if index < len(baseline) else None,
+            intervention[index] if index < len(intervention) else None,
+        )
+        for index in range(max(len(baseline), len(intervention)))
+        if (baseline[index] if index < len(baseline) else None)
+        != (intervention[index] if index < len(intervention) else None)
+    )
+
+
+def _declared_difference_indices(indices: tuple[int, ...]) -> tuple[int, ...]:
+    if not isinstance(indices, tuple) or any(type(index) is not int or index < 0 for index in indices):
+        raise PairedWorkflowValidationError("declared_workflow_differences must be a tuple of non-negative integers")
+    if indices != tuple(sorted(set(indices))):
+        raise PairedWorkflowValidationError("declared workflow difference indices must be unique and sorted")
+    return indices
+
+
+def _validate_pair_contract(
+    baseline: TDHookWorkflowRunner,
+    intervention: TDHookWorkflowRunner,
+    pair_id: str,
+) -> None:
+    if not isinstance(pair_id, str) or not pair_id:
+        raise PairedWorkflowValidationError("pair_id must be a non-empty string")
+    left = baseline.interaction.contract
+    right = intervention.interaction.contract
+    if left.model_id is None or left.checkpoint_id is None:
+        raise PairedWorkflowValidationError("paired workflows require explicit model and checkpoint identities")
+    if left.identity != right.identity or left.model_id != right.model_id or left.checkpoint_id != right.checkpoint_id:
+        raise PairedWorkflowValidationError(
+            "paired workflows must share interaction, model, and checkpoint identities"
+        )
+    if left.to_dict() != right.to_dict():
+        raise PairedWorkflowValidationError("paired workflows require identical interaction contracts")
+    if baseline.interaction.module is not intervention.interaction.module:
+        raise PairedWorkflowValidationError("paired workflows must execute against the same module instance")
+
+
+@dataclass(frozen=True, slots=True)
+class _ModuleStateSnapshot:
+    state: Mapping[str, torch.Tensor]
+    training: tuple[bool, ...]
+    gradients: tuple[torch.Tensor | None, ...]
+
+    @classmethod
+    def capture(cls, module: torch.nn.Module) -> _ModuleStateSnapshot:
+        return cls(
+            {name: value.detach().clone() for name, value in module.state_dict().items()},
+            tuple(child.training for child in module.modules()),
+            tuple(
+                parameter.grad.detach().clone() if parameter.grad is not None else None
+                for parameter in module.parameters()
+            ),
+        )
+
+    def restore(self, module: torch.nn.Module) -> None:
+        module.load_state_dict(self.state, strict=True)
+        children = tuple(module.modules())
+        if len(children) != len(self.training):
+            raise RuntimeError("paired workflow changed the module hierarchy")
+        for child, training in zip(children, self.training, strict=True):
+            child.training = training
+        parameters = tuple(module.parameters())
+        if len(parameters) != len(self.gradients):
+            raise RuntimeError("paired workflow changed the module parameter structure")
+        for parameter, gradient in zip(parameters, self.gradients, strict=True):
+            parameter.grad = gradient.detach().clone() if gradient is not None else None
+
+
+def _rng_state() -> tuple[torch.Tensor, list[torch.Tensor] | None]:
+    return torch.get_rng_state().clone(), (
+        [state.clone() for state in torch.cuda.get_rng_state_all()] if torch.cuda.is_available() else None
+    )
+
+
+def _set_rng_state(state: tuple[torch.Tensor, list[torch.Tensor] | None]) -> None:
+    torch.set_rng_state(state[0])
+    if state[1] is not None:
+        torch.cuda.set_rng_state_all(state[1])
+
+
+def _arm_reference(result: TDHookWorkflowResult) -> WorkflowArmReference:
+    provenance = result.provenance
+    return WorkflowArmReference(
+        provenance_sha256=hashlib.sha256(provenance.to_json().encode()).hexdigest(),
+        input_artifacts=tuple(item.identity for item in provenance.input_artifacts),
+        output_artifacts=tuple(item.identity for item in provenance.output_artifacts),
+    )
+
+
 def _reject_unsupported_module(module: torch.nn.Module) -> None:
     if any(hasattr(child, "_orig_mod") for child in module.modules()):
         raise NotImplementedError("torch.compile modules are not supported by the TDHook workflow runner")
@@ -217,4 +670,14 @@ def _reject_unsupported_module(module: torch.nn.Module) -> None:
         raise NotImplementedError("remote modules are not supported by the TDHook workflow runner")
 
 
-__all__ = ["OutputArtifactResolver", "TDHookWorkflowResult", "TDHookWorkflowRunner"]
+__all__ = [
+    "OutputArtifactResolver",
+    "PairedWorkflowExecutionError",
+    "PairedWorkflowValidationError",
+    "TDHookPairedWorkflowResult",
+    "TDHookWorkflowPairManifest",
+    "TDHookWorkflowResult",
+    "TDHookWorkflowRunner",
+    "WorkflowArmReference",
+    "WorkflowStepDifference",
+]

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -112,12 +112,12 @@ class TDHookWorkflowPairManifest:
         ):
             if not isinstance(value, str) or not value:
                 raise ValueError(f"{field} must be a non-empty string")
+        if not all(isinstance(item, WorkflowStepDifference) for item in self.changed_steps):
+            raise TypeError("changed_steps must contain WorkflowStepDifference values")
         if tuple(item.index for item in self.changed_steps) != tuple(
             sorted({item.index for item in self.changed_steps})
         ):
             raise ValueError("paired workflow changed step indices must be unique and sorted")
-        if not all(isinstance(item, WorkflowStepDifference) for item in self.changed_steps):
-            raise TypeError("changed_steps must contain WorkflowStepDifference values")
         if not isinstance(self.baseline, WorkflowArmReference) or not isinstance(
             self.intervention, WorkflowArmReference
         ):

--- a/tests/integration/test_paired_tdhook_workflow.py
+++ b/tests/integration/test_paired_tdhook_workflow.py
@@ -1,0 +1,256 @@
+from dataclasses import replace
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from tdhook.latent import ActivationCaching, SteeringVectors
+from tdhook.weights import Pruning
+from tdhook.workflow import Workflow
+
+from xdrl.interactions import InteractionContract, InteractionPhase, RuntimeInteractionContext
+from xdrl.provenance import (
+    ArtifactDigestAlgorithm,
+    InputArtifactReference,
+    InputArtifactRole,
+    OutputArtifactDeclaration,
+    OutputArtifactDigest,
+    OutputArtifactRole,
+)
+from xdrl.tdhook import (
+    PairedWorkflowExecutionError,
+    PairedWorkflowValidationError,
+    TDHookWorkflowPairManifest,
+    TDHookWorkflowRunner,
+)
+from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
+
+
+def _runner(*, stochastic: bool = False) -> TDHookWorkflowRunner:
+    inputs = TensorDictSchema(
+        (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),),
+        BatchSemantics(("env",)),
+    )
+    outputs = TensorDictSchema(
+        (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),),
+        BatchSemantics(("env",)),
+    )
+    layer: torch.nn.Module
+    if stochastic:
+        layer = torch.nn.Sequential(torch.nn.Dropout(p=0.5), torch.nn.Linear(2, 1, bias=False))
+    else:
+        layer = torch.nn.Linear(2, 1, bias=False)
+    linear = layer[-1] if stochastic else layer
+    assert isinstance(linear, torch.nn.Linear)
+    with torch.no_grad():
+        linear.weight.copy_(torch.tensor([[2.0, -1.0]]))
+    policy = TensorDictModule(layer, in_keys=["observation"], out_keys=["action"])
+    contract = InteractionContract(
+        "policy:evaluation:pair",
+        ModelRole.ACTOR,
+        InteractionPhase.EVALUATION,
+        "policy",
+        inputs,
+        outputs,
+        model_id="actor-v3",
+        checkpoint_id="sha256:paired",
+        module_training=stochastic,
+    )
+    batch = TensorDict({"observation": torch.tensor([[1.0, 2.0], [3.0, 4.0]])}, batch_size=[2])
+    return TDHookWorkflowRunner(RuntimeInteractionContext(contract, policy, batch))
+
+
+def _cache() -> Workflow:
+    return Workflow(ActivationCaching("module", cache_key=("activations", "head")))
+
+
+def _resolve_artifacts(
+    _data: TensorDict, declarations: tuple[OutputArtifactDeclaration, ...]
+) -> tuple[OutputArtifactDigest, ...]:
+    return tuple(
+        OutputArtifactDigest(item.identity, ArtifactDigestAlgorithm.SHA256, "2" * 64) for item in declarations
+    )
+
+
+@pytest.mark.integration
+def test_no_op_pair_matches_rng_and_returns_native_results_with_tensor_free_manifest() -> None:
+    runner = _runner(stochastic=True)
+    data = runner.interaction.representative_input
+    torch.manual_seed(7)
+    initial_rng = torch.get_rng_state().clone()
+    runner.run(_cache(), data.clone(), code_revision="test-revision")
+    expected_final_rng = torch.get_rng_state().clone()
+    torch.set_rng_state(initial_rng)
+    checkpoint = InputArtifactReference(
+        "checkpoint:actor-v3",
+        InputArtifactRole.MODEL_CHECKPOINT,
+        ArtifactDigestAlgorithm.SHA256,
+        "1" * 64,
+    )
+    baseline_artifact = OutputArtifactDeclaration("result:baseline", OutputArtifactRole.INTERVENTION_RESULT)
+    intervention_artifact = OutputArtifactDeclaration("result:intervention", OutputArtifactRole.INTERVENTION_RESULT)
+
+    pair = runner.run_paired(
+        _cache(),
+        _cache(),
+        data,
+        pair_id="pair:no-op",
+        code_revision="test-revision",
+        input_artifacts=(checkpoint,),
+        baseline_output_artifacts=(baseline_artifact,),
+        baseline_output_artifact_resolver=_resolve_artifacts,
+        intervention_output_artifacts=(intervention_artifact,),
+        intervention_output_artifact_resolver=_resolve_artifacts,
+    )
+
+    torch.testing.assert_close(pair.baseline.data["action"], pair.intervention.data["action"])
+    assert pair.baseline.provenance.model_calls == pair.intervention.provenance.model_calls == 1
+    assert torch.equal(torch.get_rng_state(), expected_final_rng)
+    assert pair.manifest.changed_steps == ()
+    assert pair.manifest.matched_rng_sources[0] == "torch_cpu"
+    assert "python_random" in pair.manifest.unsupported_randomness_sources
+    assert pair.manifest.interpretation == "mechanics_and_provenance_only"
+    assert len(pair.manifest.baseline.provenance_sha256) == 64
+    assert pair.manifest.baseline.input_artifacts == ("checkpoint:actor-v3",)
+    assert pair.manifest.baseline.output_artifacts == ("result:baseline",)
+    assert pair.manifest.intervention.output_artifacts == ("result:intervention",)
+    assert TDHookWorkflowPairManifest.from_json(pair.manifest.to_json()) == pair.manifest
+    assert "Tensor" not in pair.manifest.to_json()
+    assert "action" not in data.keys()
+    assert pair.baseline.data is not pair.intervention.data
+
+
+def _keep_intervention_output(*, output: torch.Tensor, **_: object) -> torch.Tensor:
+    return output
+
+
+def _zero_intervention_output(*, output: torch.Tensor, **_: object) -> torch.Tensor:
+    return torch.zeros_like(output)
+
+
+@pytest.mark.integration
+def test_pair_records_a_declared_nontrivial_activation_intervention() -> None:
+    runner = _runner()
+    data = runner.interaction.representative_input.clone()
+    baseline = Workflow(SteeringVectors(["module"], steer_fn=_keep_intervention_output))
+    intervention = Workflow(SteeringVectors(["module"], steer_fn=_zero_intervention_output))
+
+    pair = runner.run_paired(
+        baseline,
+        intervention,
+        data,
+        pair_id="pair:activation",
+        code_revision="test-revision",
+        declared_workflow_differences=(0,),
+        callback_identifiers={
+            _keep_intervention_output: "keep_activation",
+            _zero_intervention_output: "zero_activation",
+        },
+    )
+
+    assert tuple(item.index for item in pair.manifest.changed_steps) == (0,)
+    assert not torch.equal(pair.baseline.data["action"], pair.intervention.data["action"])
+    assert not any(child._forward_hooks for child in runner.interaction.module.modules())
+
+
+def _importance(*, parameter: torch.Tensor, **_: object) -> torch.Tensor:
+    return parameter.abs()
+
+
+@pytest.mark.integration
+def test_parameter_intervention_is_applied_only_to_its_arm_and_restored() -> None:
+    runner = _runner()
+    original = {name: value.detach().clone() for name, value in runner.interaction.module.state_dict().items()}
+    baseline = Workflow(Pruning(importance_callback=_importance, amount_to_prune=0, relative_path="module"))
+    intervention = Workflow(Pruning(importance_callback=_importance, amount_to_prune=1, relative_path="module"))
+
+    pair = runner.run_paired(
+        baseline,
+        intervention,
+        runner.interaction.representative_input,
+        pair_id="pair:parameter",
+        code_revision="test-revision",
+        declared_workflow_differences=(0,),
+        callback_identifiers={_importance: "absolute_parameter_importance"},
+    )
+
+    assert torch.count_nonzero(pair.baseline.data["action"])
+    assert not torch.equal(pair.baseline.data["action"], pair.intervention.data["action"])
+    torch.testing.assert_close(pair.intervention.data["action"], torch.tensor([[2.0], [6.0]]))
+    for name, value in runner.interaction.module.state_dict().items():
+        torch.testing.assert_close(value, original[name])
+
+
+class _FailingWorkflow(Workflow):
+    def run_with_plan(self, model: torch.nn.Module, data: TensorDict):  # type: ignore[no-untyped-def]
+        super().run_with_plan(model, data)
+        raise RuntimeError("arm exploded")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("failed_arm", ["baseline", "intervention"])
+def test_failure_in_either_arm_restores_module_rng_and_hooks(failed_arm: str) -> None:
+    runner = _runner(stochastic=True)
+    good = _cache()
+    failed = _FailingWorkflow(ActivationCaching("module", cache_key=("activations", "head")))
+    workflows = (failed, good) if failed_arm == "baseline" else (good, failed)
+    original = {name: value.detach().clone() for name, value in runner.interaction.module.state_dict().items()}
+    torch.manual_seed(17)
+    initial_rng = torch.get_rng_state().clone()
+
+    with pytest.raises(PairedWorkflowExecutionError, match=failed_arm) as caught:
+        runner.run_paired(
+            *workflows,
+            runner.interaction.representative_input,
+            pair_id=f"pair:failure:{failed_arm}",
+            code_revision="test-revision",
+        )
+
+    assert caught.value.arm == failed_arm
+    assert (caught.value.baseline is not None) is (failed_arm == "intervention")
+    expected_rng = initial_rng
+    if failed_arm == "intervention":
+        torch.set_rng_state(initial_rng)
+        runner.run(good, runner.interaction.representative_input.clone(), code_revision="test-revision")
+        expected_rng = torch.get_rng_state().clone()
+    assert torch.equal(torch.get_rng_state(), expected_rng)
+    for name, value in runner.interaction.module.state_dict().items():
+        torch.testing.assert_close(value, original[name])
+    assert not any(child._forward_hooks for child in runner.interaction.module.modules())
+
+
+@pytest.mark.integration
+def test_pair_rejects_undeclared_differences_and_incompatible_contracts_before_execution() -> None:
+    runner = _runner()
+    baseline = Workflow(Pruning(importance_callback=_importance, amount_to_prune=0, relative_path="module"))
+    intervention = Workflow(Pruning(importance_callback=_importance, amount_to_prune=1, relative_path="module"))
+
+    with pytest.raises(PairedWorkflowValidationError, match="do not match declaration"):
+        runner.run_paired(
+            baseline,
+            intervention,
+            runner.interaction.representative_input,
+            pair_id="pair:undeclared",
+            code_revision="test-revision",
+            callback_identifiers={_importance: "absolute_parameter_importance"},
+        )
+
+    other_contract = replace(runner.interaction.contract, checkpoint_id="sha256:different")
+    other = TDHookWorkflowRunner(
+        RuntimeInteractionContext(
+            other_contract,
+            runner.interaction.module,
+            runner.interaction.representative_input,
+        )
+    )
+    with pytest.raises(PairedWorkflowValidationError, match="interaction, model, and checkpoint"):
+        runner.run_paired(
+            _cache(),
+            _cache(),
+            runner.interaction.representative_input,
+            pair_id="pair:incompatible",
+            code_revision="test-revision",
+            intervention_runner=other,
+        )
+
+    assert not runner.interaction.events

--- a/tests/integration/test_paired_tdhook_workflow.py
+++ b/tests/integration/test_paired_tdhook_workflow.py
@@ -6,7 +6,7 @@ from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
 from tdhook.latent import ActivationCaching, SteeringVectors
 from tdhook.weights import Pruning
-from tdhook.workflow import Workflow
+from tdhook.workflow import Workflow, WorkflowUpdate
 
 from xdrl.interactions import InteractionContract, InteractionPhase, RuntimeInteractionContext
 from xdrl.provenance import (
@@ -28,7 +28,7 @@ from xdrl.tdhook import (
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
 
-def _runner(*, stochastic: bool = False) -> TDHookWorkflowRunner:
+def _runner(*, stochastic: bool = False, layer: torch.nn.Module | None = None) -> TDHookWorkflowRunner:
     inputs = TensorDictSchema(
         (KeySchema("observation", KeyRole.OBSERVATION, KeyPresence.REQUIRED),),
         BatchSemantics(("env",)),
@@ -37,12 +37,12 @@ def _runner(*, stochastic: bool = False) -> TDHookWorkflowRunner:
         (KeySchema("action", KeyRole.ACTION, KeyPresence.PRODUCED),),
         BatchSemantics(("env",)),
     )
-    layer: torch.nn.Module
-    if stochastic:
-        layer = torch.nn.Sequential(torch.nn.Dropout(p=0.5), torch.nn.Linear(2, 1, bias=False))
-    else:
-        layer = torch.nn.Linear(2, 1, bias=False)
-    linear = layer[-1] if stochastic else layer
+    if layer is None:
+        if stochastic:
+            layer = torch.nn.Sequential(torch.nn.Dropout(p=0.5), torch.nn.Linear(2, 1, bias=False))
+        else:
+            layer = torch.nn.Linear(2, 1, bias=False)
+    linear = layer[-1] if isinstance(layer, torch.nn.Sequential) else layer
     assert isinstance(linear, torch.nn.Linear)
     with torch.no_grad():
         linear.weight.copy_(torch.tensor([[2.0, -1.0]]))
@@ -319,6 +319,14 @@ def test_pair_manifest_rejects_invalid_values(factory: object, message: str) -> 
         ({}, "missing or unknown fields"),
         ({**_manifest().to_dict(), "changed_steps": "invalid"}, "changed_steps must be an array"),
         ({**_manifest().to_dict(), "baseline": {}}, "baseline arm reference"),
+        (
+            {
+                **_manifest().to_dict(),
+                "baseline": {**_manifest().to_dict()["baseline"], "input_artifacts": "artifact"},
+            },
+            "baseline.input_artifacts must be an array",
+        ),
+        ({**_manifest().to_dict(), "matched_rng_sources": "torch_cpu"}, "matched_rng_sources must be an array"),
     ],
 )
 def test_pair_manifest_decoder_rejects_invalid_payloads(payload: object, message: str) -> None:
@@ -393,6 +401,23 @@ def test_pair_rejects_missing_identity_contract_drift_and_a_different_module() -
             intervention_runner=different_module,
         )
 
+    separate_context = TDHookWorkflowRunner(
+        RuntimeInteractionContext(
+            runner.interaction.contract,
+            runner.interaction.module,
+            data,
+        )
+    )
+    with pytest.raises(PairedWorkflowValidationError, match="same runtime interaction context"):
+        runner.run_paired(
+            _cache(),
+            _cache(),
+            data,
+            pair_id="pair:different-context",
+            code_revision="test-revision",
+            intervention_runner=separate_context,
+        )
+
 
 @pytest.mark.integration
 def test_pair_rejects_unshared_tensordict_operators() -> None:
@@ -408,3 +433,66 @@ def test_pair_rejects_unshared_tensordict_operators() -> None:
             pair_id="pair:operators",
             code_revision="test-revision",
         )
+
+
+class _MutatingLinear(torch.nn.Linear):
+    def __init__(self) -> None:
+        super().__init__(2, 1, bias=False)
+        self.register_buffer("counter", torch.zeros((), dtype=torch.int64), persistent=False)
+        self.seen: list[int] = []
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        self.counter.add_(1)
+        self.seen.append(int(self.counter))
+        return super().forward(value)
+
+
+class _MutatingIdentity(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("counter", torch.zeros((), dtype=torch.int64), persistent=False)
+        self.seen: list[int] = []
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        self.counter.add_(1)
+        self.seen.append(int(self.counter))
+        return value
+
+
+@pytest.mark.integration
+def test_pair_restores_nonpersistent_interaction_buffers_between_arms_and_afterward() -> None:
+    layer = _MutatingLinear()
+    runner = _runner(layer=layer)
+
+    pair = runner.run_paired(
+        _cache(),
+        _cache(),
+        runner.interaction.representative_input,
+        pair_id="pair:nonpersistent-buffer",
+        code_revision="test-revision",
+    )
+
+    torch.testing.assert_close(pair.baseline.data["action"], pair.intervention.data["action"])
+    assert layer.seen == [1, 1]
+    assert not layer.counter
+
+
+@pytest.mark.integration
+def test_pair_restores_shared_operator_state_between_arms_and_afterward() -> None:
+    runner = _runner()
+    layer = _MutatingIdentity()
+    operator = TensorDictModule(layer, in_keys=["observation"], out_keys=["observation"])
+    baseline = Workflow(WorkflowUpdate(operator), ActivationCaching("module"))
+    intervention = Workflow(WorkflowUpdate(operator), ActivationCaching("module"))
+
+    pair = runner.run_paired(
+        baseline,
+        intervention,
+        runner.interaction.representative_input,
+        pair_id="pair:stateful-operator",
+        code_revision="test-revision",
+    )
+
+    torch.testing.assert_close(pair.baseline.data["action"], pair.intervention.data["action"])
+    assert layer.seen == [1, 1]
+    assert not layer.counter

--- a/tests/integration/test_paired_tdhook_workflow.py
+++ b/tests/integration/test_paired_tdhook_workflow.py
@@ -22,6 +22,8 @@ from xdrl.tdhook import (
     PairedWorkflowValidationError,
     TDHookWorkflowPairManifest,
     TDHookWorkflowRunner,
+    WorkflowArmReference,
+    WorkflowStepDifference,
 )
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
@@ -62,6 +64,27 @@ def _runner(*, stochastic: bool = False) -> TDHookWorkflowRunner:
 
 def _cache() -> Workflow:
     return Workflow(ActivationCaching("module", cache_key=("activations", "head")))
+
+
+def _arm_reference() -> WorkflowArmReference:
+    return WorkflowArmReference("a" * 64, (), ())
+
+
+def _manifest(**overrides: object) -> TDHookWorkflowPairManifest:
+    values = {
+        "schema_revision": 1,
+        "pair_id": "pair:test",
+        "interaction_id": "interaction:test",
+        "model_id": "model:test",
+        "checkpoint_id": "checkpoint:test",
+        "changed_steps": (),
+        "baseline": _arm_reference(),
+        "intervention": _arm_reference(),
+        "matched_rng_sources": ("torch_cpu",),
+        "unsupported_randomness_sources": ("python_random",),
+    }
+    values.update(overrides)
+    return TDHookWorkflowPairManifest(**values)  # type: ignore[arg-type]
 
 
 def _resolve_artifacts(
@@ -254,3 +277,134 @@ def test_pair_rejects_undeclared_differences_and_incompatible_contracts_before_e
         )
 
     assert not runner.interaction.events
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: WorkflowStepDifference(-1, "baseline", "intervention"), "non-negative"),
+        (lambda: WorkflowStepDifference(0, "same", "same"), "distinct"),
+        (lambda: WorkflowArmReference("invalid", (), ()), "SHA-256"),
+        (lambda: WorkflowArmReference("a" * 64, [], ()), "tuple of non-empty"),  # type: ignore[arg-type]
+        (lambda: WorkflowArmReference("a" * 64, ("duplicate", "duplicate"), ()), "unique"),
+        (lambda: _manifest(schema_revision=2), "schema revision"),
+        (lambda: _manifest(pair_id=""), "non-empty string"),
+        (
+            lambda: _manifest(
+                changed_steps=(
+                    WorkflowStepDifference(1, "a", "b"),
+                    WorkflowStepDifference(0, "c", "d"),
+                )
+            ),
+            "unique and sorted",
+        ),
+        (lambda: _manifest(changed_steps=(object(),)), "WorkflowStepDifference"),
+        (lambda: _manifest(baseline=object()), "WorkflowArmReference"),
+        (lambda: _manifest(matched_rng_sources=[]), "tuple of non-empty"),
+        (lambda: _manifest(matched_rng_sources=("torch_cpu", "torch_cpu")), "unique"),
+        (lambda: _manifest(interpretation="causal"), "cannot assign a causal"),
+    ],
+)
+def test_pair_manifest_rejects_invalid_values(factory: object, message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        factory()  # type: ignore[operator]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "must be an object"),
+        ({}, "missing or unknown fields"),
+        ({**_manifest().to_dict(), "changed_steps": "invalid"}, "changed_steps must be an array"),
+        ({**_manifest().to_dict(), "baseline": {}}, "baseline arm reference"),
+    ],
+)
+def test_pair_manifest_decoder_rejects_invalid_payloads(payload: object, message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        TDHookWorkflowPairManifest.from_dict(payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.integration
+def test_pair_manifest_json_decoder_requires_an_object() -> None:
+    with pytest.raises(TypeError, match="JSON must contain an object"):
+        TDHookWorkflowPairManifest.from_json("[]")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("declared", [[], (0, 0)])
+def test_pair_rejects_invalid_difference_declarations(declared: object) -> None:
+    runner = _runner()
+    with pytest.raises(PairedWorkflowValidationError, match="tuple of non-negative|unique and sorted"):
+        runner.run_paired(
+            _cache(),
+            _cache(),
+            runner.interaction.representative_input,
+            pair_id="pair:invalid-differences",
+            code_revision="test-revision",
+            declared_workflow_differences=declared,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.integration
+def test_pair_rejects_missing_identity_contract_drift_and_a_different_module() -> None:
+    runner = _runner()
+    data = runner.interaction.representative_input
+
+    with pytest.raises(PairedWorkflowValidationError, match="pair_id"):
+        runner.run_paired(_cache(), _cache(), data, pair_id="", code_revision="test-revision")
+
+    missing_identity = TDHookWorkflowRunner(
+        RuntimeInteractionContext(
+            replace(runner.interaction.contract, model_id=None),
+            runner.interaction.module,
+            data,
+        )
+    )
+    with pytest.raises(PairedWorkflowValidationError, match="explicit model and checkpoint"):
+        missing_identity.run_paired(_cache(), _cache(), data, pair_id="pair:missing", code_revision="test-revision")
+
+    drifted = TDHookWorkflowRunner(
+        RuntimeInteractionContext(
+            replace(runner.interaction.contract, module_training=True),
+            runner.interaction.module,
+            data,
+        )
+    )
+    with pytest.raises(PairedWorkflowValidationError, match="identical interaction contracts"):
+        runner.run_paired(
+            _cache(),
+            _cache(),
+            data,
+            pair_id="pair:drift",
+            code_revision="test-revision",
+            intervention_runner=drifted,
+        )
+
+    different_module = _runner()
+    with pytest.raises(PairedWorkflowValidationError, match="same module instance"):
+        runner.run_paired(
+            _cache(),
+            _cache(),
+            data,
+            pair_id="pair:different-module",
+            code_revision="test-revision",
+            intervention_runner=different_module,
+        )
+
+
+@pytest.mark.integration
+def test_pair_rejects_unshared_tensordict_operators() -> None:
+    runner = _runner()
+    baseline_operator = TensorDictModule(torch.nn.Identity(), in_keys=["observation"], out_keys=["observation"])
+    intervention_operator = TensorDictModule(torch.nn.Identity(), in_keys=["observation"], out_keys=["observation"])
+
+    with pytest.raises(PairedWorkflowValidationError, match="same instances"):
+        runner.run_paired(
+            Workflow(baseline_operator, ActivationCaching("module")),
+            Workflow(intervention_operator, ActivationCaching("module")),
+            runner.interaction.representative_input,
+            pair_id="pair:operators",
+            code_revision="test-revision",
+        )


### PR DESCRIPTION
## What does this PR do?

- adds `TDHookWorkflowRunner.run_paired()` for matched baseline and intervention workflows over independent TensorDict clones
- validates shared interaction/model/checkpoint contracts and requires every configured workflow difference to be declared
- matches process-global PyTorch CPU/CUDA RNG, restores module parameters, buffers, gradients, and training state, and preserves cleanup on either-arm failure
- returns both native `TDHookWorkflowResult` values plus a versioned tensor-free pair manifest with provenance SHA-256 and artifact references
- explicitly records unsupported randomness sources and limits interpretation to mechanics/provenance rather than causal claims
- adds coverage for no-op parity, activation and parameter interventions, incompatible pairs, and failure in either arm

## Validation

- `pre-commit run --all-files`
- `pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50` — 170 passed, 93.51% coverage
- warning-strict Sphinx HTML build

Closes #54