### PR TITLE
Type multi-agent value decomposition evidence

### DIFF
--- a/src/xdrl/__init__.py
+++ b/src/xdrl/__init__.py
@@ -20,6 +20,7 @@ from xdrl.compatibility import (
 )
 from xdrl.interactions import (
     AgentSelector,
+    CoalitionTerm,
     InteractionContract,
     InteractionPhase,
     InteractionTopology,
@@ -30,12 +31,16 @@ from xdrl.interactions import (
     LifecycleEvent,
     LifecycleEventType,
     MultiAgentSemantics,
+    NamedReduction,
     OccurrenceIdentityError,
     RecurrentCollectorMode,
     RecurrentSemantics,
     RecurrentStateTransition,
     RuntimeInteractionContext,
     SemanticTarget,
+    ValueDecompositionAxes,
+    ValueDecompositionKeys,
+    ValueDecompositionSemantics,
 )
 from xdrl.interventions import (
     Intervention,
@@ -104,6 +109,7 @@ except PackageNotFoundError:
 
 __all__ = [
     "AgentSelector",
+    "CoalitionTerm",
     "ArtifactDigestAlgorithm",
     "BatchSemantics",
     "CompatibilityBoundaryError",
@@ -133,6 +139,7 @@ __all__ = [
     "LifecycleEvent",
     "LifecycleEventType",
     "MultiAgentSemantics",
+    "NamedReduction",
     "OccurrenceIdentityError",
     "ModelRole",
     "ObservationKind",
@@ -157,6 +164,9 @@ __all__ = [
     "RuntimeInteractionContext",
     "SchemaValidationError",
     "SemanticTarget",
+    "ValueDecompositionAxes",
+    "ValueDecompositionKeys",
+    "ValueDecompositionSemantics",
     "SUPPORTED_DEPENDENCIES",
     "SUPPORTED_GIT_REVISIONS",
     "SUPPORTED_PYTHON",

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -273,6 +273,8 @@ class CoalitionTerm:
     axis_index: int
 
     def __post_init__(self) -> None:
+        if type(self.identity) is not str:
+            raise TypeError("coalition identity must be a string")
         if not self.identity:
             raise ValueError("coalition identity must be non-empty")
         if not self.members:
@@ -431,7 +433,7 @@ class MultiAgentSemantics:
                     raise ValueError(f"agent identity {agent!r} is outside the declared agent group")
         else:
             for agent in self.target.selector.agents:
-                if isinstance(agent, int) and not 0 <= agent < self.n_agents:
+                if type(agent) is not int or not 0 <= agent < self.n_agents:
                     raise ValueError(f"agent index {agent} is outside the declared group size {self.n_agents}")
 
     @property
@@ -1004,6 +1006,8 @@ def _validate_value_decomposition_contract(contract: InteractionContract) -> Non
         raise ValueError("value decomposition requires multi-agent semantics")
     if multi_agent.topology is not InteractionTopology.MIXER or contract.role is not ModelRole.MIXER:
         raise ValueError("value decomposition requires a mixer interaction")
+    if contract.agent_dimension in contract.batch_dimensions:
+        raise ValueError("value-decomposition agent_dimension must be distinct from leading batch dimensions")
 
     reserved_axes = set(contract.batch_dimensions)
     reserved_axes.add(contract.agent_dimension or "")
@@ -1021,6 +1025,8 @@ def _validate_value_decomposition_contract(contract: InteractionContract) -> Non
         *semantics.feature_axes,
     }
     for role, axes in asdict(semantics.axes).items():
+        if tuple(axes[: len(contract.batch_dimensions)]) != contract.batch_dimensions:
+            raise ValueError(f"{role} axes must begin with the declared batch dimensions in order")
         unknown = set(axes) - allowed_axes
         if unknown:
             raise ValueError(f"{role} declares unknown axes: {', '.join(sorted(unknown))}")
@@ -1064,17 +1070,31 @@ def _validate_value_decomposition_contract(contract: InteractionContract) -> Non
             raise ValueError(f"value-decomposition {name} key is not declared in the interaction schemas")
         if entry.role is not role_by_name[name]:
             raise ValueError(f"value-decomposition {name} key must use the {role_by_name[name].value} role")
-        if entry.spec is not None and len(getattr(semantics.axes, name)) != len(contract.batch_dimensions) + len(
-            entry.spec.shape
-        ):
+        tensor_axes = getattr(semantics.axes, name)
+        semantic_extents = {
+            semantics.coalition_axis: len(semantics.terms),
+            contract.agent_dimension: multi_agent.n_agents,
+        }
+        axes_with_declared_extents = set(tensor_axes) & set(semantic_extents)
+        if entry.spec is None and axes_with_declared_extents:
+            raise ValueError(f"value-decomposition {name} requires a spec to validate semantic-axis extents")
+        if entry.spec is not None and len(tensor_axes) != len(contract.batch_dimensions) + len(entry.spec.shape):
             raise ValueError(f"value-decomposition {name} axes do not match its declared tensor rank")
+        if entry.spec is not None:
+            for axis in axes_with_declared_extents:
+                feature_index = tensor_axes.index(axis) - len(contract.batch_dimensions)
+                if entry.spec.shape[feature_index] != semantic_extents[axis]:
+                    raise ValueError(f"value-decomposition {name} {axis} extent must be {semantic_extents[axis]}")
 
+    coalition_path = _key_path(semantics.keys.coalition_contribution)
     joint_path = _key_path(semantics.keys.joint_value)
     if not any(
-        _key_path(reduction.target_key) == joint_path and semantics.coalition_axis in reduction.reduced_axes
+        _key_path(reduction.source_key) == coalition_path
+        and _key_path(reduction.target_key) == joint_path
+        and semantics.coalition_axis in reduction.reduced_axes
         for reduction in semantics.reductions
     ):
-        raise ValueError("joint_value requires a named reduction over the coalition axis")
+        raise ValueError("joint_value requires a named reduction from coalition_contribution over the coalition axis")
     for reduction in semantics.reductions:
         if (
             _key_path(reduction.source_key) not in declared_paths

--- a/src/xdrl/interactions.py
+++ b/src/xdrl/interactions.py
@@ -261,6 +261,137 @@ class AgentSelector:
             raise ValueError("agent selector contains duplicate agents")
 
 
+AgentIdentity = str | int
+
+
+@dataclass(frozen=True, slots=True)
+class CoalitionTerm:
+    """One semantic coalition coordinate, independent of module structure."""
+
+    identity: str
+    members: tuple[AgentIdentity, ...]
+    axis_index: int
+
+    def __post_init__(self) -> None:
+        if not self.identity:
+            raise ValueError("coalition identity must be non-empty")
+        if not self.members:
+            raise ValueError("coalition membership must be non-empty")
+        if any(type(member) not in {str, int} or member == "" for member in self.members):
+            raise TypeError("coalition members must be non-empty strings or integers")
+        if len(set(self.members)) != len(self.members):
+            raise ValueError("coalition membership contains duplicate agents")
+        if type(self.axis_index) is not int or self.axis_index < 0:
+            raise ValueError("coalition axis_index must be a non-negative integer")
+
+
+@dataclass(frozen=True, slots=True)
+class ValueDecompositionKeys:
+    """Nested TensorDict keys used by a value-decomposition interaction."""
+
+    individual_value: TensorDictKey
+    coalition_contribution: TensorDictKey
+    semantic_mask: TensorDictKey
+    mixer_input: TensorDictKey
+    joint_value: TensorDictKey
+
+    def __post_init__(self) -> None:
+        paths = tuple(_key_path(key) for key in asdict(self).values())
+        if any(not path or any(not part for part in path) for path in paths):
+            raise ValueError("value-decomposition keys must be non-empty")
+        if len(set(paths)) != len(paths):
+            raise ValueError("value-decomposition keys must be unique")
+
+
+@dataclass(frozen=True, slots=True)
+class ValueDecompositionAxes:
+    """Semantic axes for each value-decomposition tensor."""
+
+    individual_value: tuple[str, ...]
+    coalition_contribution: tuple[str, ...]
+    semantic_mask: tuple[str, ...]
+    mixer_input: tuple[str, ...]
+    joint_value: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        for role, axes in asdict(self).items():
+            if not axes:
+                raise ValueError(f"{role} axes must be explicit")
+            if any(not axis for axis in axes):
+                raise ValueError(f"{role} axes must be non-empty")
+            if len(set(axes)) != len(axes):
+                raise ValueError(f"{role} axes contain duplicates")
+
+
+@dataclass(frozen=True, slots=True)
+class NamedReduction:
+    """A provenance-bearing aggregation between declared TensorDict keys."""
+
+    name: str
+    source_key: TensorDictKey
+    target_key: TensorDictKey
+    reduced_axes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("reduction name must be non-empty")
+        if not self.reduced_axes or any(not axis for axis in self.reduced_axes):
+            raise ValueError("reduced_axes must be explicit and non-empty")
+        if len(set(self.reduced_axes)) != len(self.reduced_axes):
+            raise ValueError("reduced_axes contains duplicates")
+        if _key_path(self.source_key) == _key_path(self.target_key):
+            raise ValueError("reduction source and target keys must differ")
+
+
+@dataclass(frozen=True, slots=True)
+class ValueDecompositionSemantics:
+    """Coalition identities, tensor axes, keys, and explicit aggregations."""
+
+    coalition_axis: str
+    feature_axes: tuple[str, ...]
+    terms: tuple[CoalitionTerm, ...]
+    keys: ValueDecompositionKeys
+    axes: ValueDecompositionAxes
+    reductions: tuple[NamedReduction, ...]
+    parameters_shared: bool = False
+    coalition_targets: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.coalition_axis:
+            raise ValueError("coalition_axis must be non-empty")
+        if any(not axis for axis in self.feature_axes) or len(set(self.feature_axes)) != len(self.feature_axes):
+            raise ValueError("feature axes must be non-empty and unique")
+        if not self.terms:
+            raise ValueError("value decomposition requires coalition terms")
+        identities = {term.identity for term in self.terms}
+        if len(identities) != len(self.terms):
+            raise ValueError("coalition identities must be unique")
+        memberships = tuple(term.members for term in self.terms)
+        if len(set(memberships)) != len(memberships):
+            raise ValueError("coalition memberships must be unique")
+        if tuple(term.axis_index for term in self.terms) != tuple(range(len(self.terms))):
+            raise ValueError("coalition axis indices must be contiguous and order-stable from zero")
+        if not self.reductions:
+            raise ValueError("value decomposition requires at least one named reduction")
+        if len({reduction.name for reduction in self.reductions}) != len(self.reductions):
+            raise ValueError("reduction names must be unique")
+        if type(self.parameters_shared) is not bool:
+            raise TypeError("parameters_shared must be a boolean")
+        if len(set(self.coalition_targets)) != len(self.coalition_targets):
+            raise ValueError("coalition targets must be unique")
+        unknown_targets = set(self.coalition_targets) - identities
+        if unknown_targets:
+            raise ValueError(f"unknown coalition targets: {', '.join(sorted(unknown_targets))}")
+
+    @property
+    def targeted_terms(self) -> tuple[CoalitionTerm, ...]:
+        """Return selected semantic terms in canonical coalition-axis order."""
+        if not self.coalition_targets:
+            return self.terms
+        selected = set(self.coalition_targets)
+        return tuple(term for term in self.terms if term.identity in selected)
+
+
 @dataclass(frozen=True, slots=True)
 class SemanticTarget:
     """Target a model role and agent group without treating paths as identities."""
@@ -277,6 +408,7 @@ class MultiAgentSemantics:
     group: str
     n_agents: int
     target: SemanticTarget
+    agent_identities: tuple[AgentIdentity, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.group:
@@ -285,9 +417,27 @@ class MultiAgentSemantics:
             raise ValueError("n_agents must be positive")
         if self.target.selector.group != self.group:
             raise ValueError("semantic target group must match the multi-agent group")
-        for agent in self.target.selector.agents:
-            if isinstance(agent, int) and not 0 <= agent < self.n_agents:
-                raise ValueError(f"agent index {agent} is outside the declared group size {self.n_agents}")
+        if self.agent_identities:
+            if len(self.agent_identities) != self.n_agents:
+                raise ValueError("agent_identities must match the declared group size")
+            if len(set(self.agent_identities)) != len(self.agent_identities):
+                raise ValueError("agent_identities must be unique")
+            if any(type(agent) not in {str, int} or agent == "" for agent in self.agent_identities):
+                raise TypeError("agent identities must be non-empty strings or integers")
+        if self.agent_identities:
+            declared = set(self.agent_identities)
+            for agent in self.target.selector.agents:
+                if agent not in declared:
+                    raise ValueError(f"agent identity {agent!r} is outside the declared agent group")
+        else:
+            for agent in self.target.selector.agents:
+                if isinstance(agent, int) and not 0 <= agent < self.n_agents:
+                    raise ValueError(f"agent index {agent} is outside the declared group size {self.n_agents}")
+
+    @property
+    def declared_agents(self) -> tuple[AgentIdentity, ...]:
+        """Return the canonical ordered semantic identities for the group."""
+        return self.agent_identities or tuple(range(self.n_agents))
 
 
 @dataclass(frozen=True, slots=True)
@@ -358,6 +508,7 @@ class InteractionContract:
     module_training: bool | None = None
     recurrent: RecurrentSemantics | None = None
     multi_agent: MultiAgentSemantics | None = None
+    value_decomposition: ValueDecompositionSemantics | None = None
     internal_computation: InternalComputationSemantics | None = None
 
     def __post_init__(self) -> None:
@@ -375,6 +526,8 @@ class InteractionContract:
             _validate_recurrent_contract(self)
         if self.multi_agent is not None:
             _validate_multi_agent_contract(self)
+        if self.value_decomposition is not None:
+            _validate_value_decomposition_contract(self)
         if self.internal_computation is not None:
             _validate_internal_computation_contract(self)
 
@@ -405,6 +558,9 @@ class InteractionContract:
             "module_training": self.module_training,
             "recurrent": asdict(self.recurrent) if self.recurrent is not None else None,
             "multi_agent": asdict(self.multi_agent) if self.multi_agent is not None else None,
+            "value_decomposition": (
+                asdict(self.value_decomposition) if self.value_decomposition is not None else None
+            ),
             "internal_computation": (
                 asdict(self.internal_computation) if self.internal_computation is not None else None
             ),
@@ -838,6 +994,102 @@ def _validate_multi_agent_contract(contract: InteractionContract) -> None:
         raise ValueError("centralised-critic interactions require a critic or value role")
     if semantics.topology is InteractionTopology.MIXER and contract.role is not ModelRole.MIXER:
         raise ValueError("mixer interactions require the mixer model role")
+
+
+def _validate_value_decomposition_contract(contract: InteractionContract) -> None:
+    semantics = contract.value_decomposition
+    multi_agent = contract.multi_agent
+    assert semantics is not None
+    if multi_agent is None:
+        raise ValueError("value decomposition requires multi-agent semantics")
+    if multi_agent.topology is not InteractionTopology.MIXER or contract.role is not ModelRole.MIXER:
+        raise ValueError("value decomposition requires a mixer interaction")
+
+    reserved_axes = set(contract.batch_dimensions)
+    reserved_axes.add(contract.agent_dimension or "")
+    reserved_axes.update(semantics.feature_axes)
+    if semantics.coalition_axis in reserved_axes:
+        raise ValueError("coalition_axis must be distinct from environment, time, agent, and feature axes")
+    if contract.agent_dimension in semantics.feature_axes or set(contract.batch_dimensions) & set(
+        semantics.feature_axes
+    ):
+        raise ValueError("feature axes must be distinct from environment, time, and agent axes")
+
+    allowed_axes = set(contract.batch_dimensions) | {
+        contract.agent_dimension or "",
+        semantics.coalition_axis,
+        *semantics.feature_axes,
+    }
+    for role, axes in asdict(semantics.axes).items():
+        unknown = set(axes) - allowed_axes
+        if unknown:
+            raise ValueError(f"{role} declares unknown axes: {', '.join(sorted(unknown))}")
+    if contract.agent_dimension not in semantics.axes.individual_value:
+        raise ValueError("individual_value axes must retain the agent dimension")
+    for role, axes in (
+        ("coalition_contribution", semantics.axes.coalition_contribution),
+        ("semantic_mask", semantics.axes.semantic_mask),
+    ):
+        if semantics.coalition_axis not in axes:
+            raise ValueError(f"{role} axes must retain the coalition axis")
+
+    declared_agents = multi_agent.declared_agents
+    declared_set = set(declared_agents)
+    for term in semantics.terms:
+        if not set(term.members) <= declared_set:
+            raise ValueError(f"coalition {term.identity!r} contains agents outside the declared group")
+        canonical = tuple(agent for agent in declared_agents if agent in term.members)
+        if term.members != canonical:
+            raise ValueError(f"coalition {term.identity!r} members must follow declared agent order")
+
+    entries = {
+        _key_path(entry.key): entry
+        for schema in (contract.input_schema, contract.output_schema)
+        for entry in schema.keys
+    }
+    role_by_name = {
+        "individual_value": KeyRole.INDIVIDUAL_VALUE,
+        "coalition_contribution": KeyRole.COALITION_CONTRIBUTION,
+        "semantic_mask": KeyRole.SEMANTIC_MASK,
+        "mixer_input": KeyRole.MIXER_INPUT,
+        "joint_value": KeyRole.JOINT_VALUE,
+    }
+    declared_paths = {_key_path(key) for key in asdict(semantics.keys).values()}
+    axes_by_path = {
+        _key_path(key): tuple(getattr(semantics.axes, name)) for name, key in asdict(semantics.keys).items()
+    }
+    for name, key in asdict(semantics.keys).items():
+        entry = entries.get(_key_path(key))
+        if entry is None:
+            raise ValueError(f"value-decomposition {name} key is not declared in the interaction schemas")
+        if entry.role is not role_by_name[name]:
+            raise ValueError(f"value-decomposition {name} key must use the {role_by_name[name].value} role")
+        if entry.spec is not None and len(getattr(semantics.axes, name)) != len(contract.batch_dimensions) + len(
+            entry.spec.shape
+        ):
+            raise ValueError(f"value-decomposition {name} axes do not match its declared tensor rank")
+
+    joint_path = _key_path(semantics.keys.joint_value)
+    if not any(
+        _key_path(reduction.target_key) == joint_path and semantics.coalition_axis in reduction.reduced_axes
+        for reduction in semantics.reductions
+    ):
+        raise ValueError("joint_value requires a named reduction over the coalition axis")
+    for reduction in semantics.reductions:
+        if (
+            _key_path(reduction.source_key) not in declared_paths
+            or _key_path(reduction.target_key) not in declared_paths
+        ):
+            raise ValueError("named reductions must reference declared value-decomposition keys")
+        if not set(reduction.reduced_axes) <= allowed_axes:
+            raise ValueError("named reduction references unknown axes")
+        source_axes = axes_by_path[_key_path(reduction.source_key)]
+        target_axes = axes_by_path[_key_path(reduction.target_key)]
+        if not set(reduction.reduced_axes) <= set(source_axes):
+            raise ValueError("named reduction axes must exist on its source tensor")
+        remaining_axes = tuple(axis for axis in source_axes if axis not in reduction.reduced_axes)
+        if remaining_axes != target_axes:
+            raise ValueError("named reduction target axes must equal its unreduced source axes")
 
 
 def _validate_internal_computation_contract(contract: InteractionContract) -> None:

--- a/src/xdrl/provenance.py
+++ b/src/xdrl/provenance.py
@@ -15,6 +15,7 @@ from tdhook.workflow import CompatibilityDecision, PlannedExecution, WorkflowPla
 from xdrl.compatibility import installed_dependency_versions
 from xdrl.interactions import (
     AgentSelector,
+    CoalitionTerm,
     InteractionTopology,
     InteractionContract,
     InteractionPhase,
@@ -24,14 +25,18 @@ from xdrl.interactions import (
     LifecycleEvent,
     LifecycleEventType,
     MultiAgentSemantics,
+    NamedReduction,
     RecurrentCollectorMode,
     RecurrentSemantics,
     RecurrentStateTransition,
     SemanticTarget,
+    ValueDecompositionAxes,
+    ValueDecompositionKeys,
+    ValueDecompositionSemantics,
 )
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
-WORKFLOW_PROVENANCE_SCHEMA_REVISION = 4
+WORKFLOW_PROVENANCE_SCHEMA_REVISION = 5
 
 
 class ProvenanceSchemaError(ValueError):
@@ -431,6 +436,11 @@ class WorkflowProvenance:
                     "workflow provenance schema revision 3 predates internal-computation semantics; "
                     "decode it with an XDRL version that supports revision 3"
                 )
+            if revision == 4:
+                raise ProvenanceSchemaError(
+                    "workflow provenance schema revision 4 predates value-decomposition semantics; "
+                    "decode it with an XDRL version that supports revision 4"
+                )
             raise ProvenanceSchemaError(
                 f"unsupported workflow provenance schema revision {revision!r}; "
                 f"expected {WORKFLOW_PROVENANCE_SCHEMA_REVISION}"
@@ -507,6 +517,7 @@ _CONTRACT_FIELDS = {
     "module_training",
     "recurrent",
     "multi_agent",
+    "value_decomposition",
     "internal_computation",
 }
 
@@ -541,6 +552,9 @@ def _contract_projection(value: Any) -> dict[str, Any]:
         contract[name] = _optional_identifier(entry[name], f"{field}.{name}")
     contract["recurrent"] = _recurrent_projection(entry["recurrent"], f"{field}.recurrent")
     contract["multi_agent"] = _multi_agent_projection(entry["multi_agent"], f"{field}.multi_agent")
+    contract["value_decomposition"] = _value_decomposition_projection(
+        entry["value_decomposition"], f"{field}.value_decomposition"
+    )
     contract["internal_computation"] = _internal_computation_projection(
         entry["internal_computation"], f"{field}.internal_computation"
     )
@@ -598,6 +612,34 @@ def _validate_canonical_contract(contract: Mapping[str, Any]) -> None:
                 ModelRole(target["role"]),
                 AgentSelector(selector["group"], tuple(selector["agents"])),
             ),
+            agent_identities=tuple(multi_agent_value["agent_identities"]),
+        )
+
+    value_decomposition_value = contract["value_decomposition"]
+    value_decomposition = None
+    if value_decomposition_value is not None:
+        keys = value_decomposition_value["keys"]
+        axes = value_decomposition_value["axes"]
+        value_decomposition = ValueDecompositionSemantics(
+            coalition_axis=value_decomposition_value["coalition_axis"],
+            feature_axes=tuple(value_decomposition_value["feature_axes"]),
+            terms=tuple(
+                CoalitionTerm(item["identity"], tuple(item["members"]), item["axis_index"])
+                for item in value_decomposition_value["terms"]
+            ),
+            keys=ValueDecompositionKeys(**{name: tuple(value) for name, value in keys.items()}),
+            axes=ValueDecompositionAxes(**{name: tuple(value) for name, value in axes.items()}),
+            reductions=tuple(
+                NamedReduction(
+                    item["name"],
+                    tuple(item["source_key"]),
+                    tuple(item["target_key"]),
+                    tuple(item["reduced_axes"]),
+                )
+                for item in value_decomposition_value["reductions"]
+            ),
+            parameters_shared=value_decomposition_value["parameters_shared"],
+            coalition_targets=tuple(value_decomposition_value["coalition_targets"]),
         )
 
     internal_value = contract["internal_computation"]
@@ -639,6 +681,7 @@ def _validate_canonical_contract(contract: Mapping[str, Any]) -> None:
             module_training=contract["module_training"],
             recurrent=recurrent,
             multi_agent=multi_agent,
+            value_decomposition=value_decomposition,
             internal_computation=internal_computation,
         )
     except (TypeError, ValueError, NotImplementedError) as error:
@@ -715,7 +758,7 @@ def _recurrent_projection(value: Any, field: str) -> dict[str, Any] | None:
 def _multi_agent_projection(value: Any, field: str) -> dict[str, Any] | None:
     if value is None:
         return None
-    entry = _exact_mapping(value, field, {"topology", "group", "n_agents", "target"})
+    entry = _exact_mapping(value, field, {"topology", "group", "n_agents", "target", "agent_identities"})
     target = _exact_mapping(entry["target"], f"{field}.target", {"role", "selector"})
     selector = _exact_mapping(target["selector"], f"{field}.target.selector", {"group", "agents"})
     agents_value = selector["agents"]
@@ -723,10 +766,16 @@ def _multi_agent_projection(value: Any, field: str) -> dict[str, Any] | None:
         type(agent) not in (str, int) or (isinstance(agent, str) and not agent) for agent in agents_value
     ):
         raise ProvenanceSchemaError(f"{field}.target.selector.agents must be an array of identifiers")
+    identities_value = entry["agent_identities"]
+    if not isinstance(identities_value, list) or any(
+        type(agent) not in (str, int) or (isinstance(agent, str) and not agent) for agent in identities_value
+    ):
+        raise ProvenanceSchemaError(f"{field}.agent_identities must be an array of identifiers")
     return {
         "topology": _enum_string(entry["topology"], InteractionTopology, f"{field}.topology"),
         "group": _nonempty_string(entry["group"], f"{field}.group"),
         "n_agents": _integer(entry["n_agents"], f"{field}.n_agents", minimum=1),
+        "agent_identities": list(identities_value),
         "target": {
             "role": _enum_string(target["role"], ModelRole, f"{field}.target.role"),
             "selector": {
@@ -734,6 +783,83 @@ def _multi_agent_projection(value: Any, field: str) -> dict[str, Any] | None:
                 "agents": list(agents_value),
             },
         },
+    }
+
+
+_VALUE_DECOMPOSITION_ROLES = {
+    "individual_value",
+    "coalition_contribution",
+    "semantic_mask",
+    "mixer_input",
+    "joint_value",
+}
+
+
+def _value_decomposition_projection(value: Any, field: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    entry = _exact_mapping(
+        value,
+        field,
+        {
+            "coalition_axis",
+            "feature_axes",
+            "terms",
+            "keys",
+            "axes",
+            "reductions",
+            "parameters_shared",
+            "coalition_targets",
+        },
+    )
+    terms_value = entry["terms"]
+    reductions_value = entry["reductions"]
+    if not isinstance(terms_value, list) or not isinstance(reductions_value, list):
+        raise ProvenanceSchemaError(f"{field}.terms and {field}.reductions must be arrays")
+    terms = []
+    for index, value in enumerate(terms_value):
+        term_field = f"{field}.terms[{index}]"
+        term = _exact_mapping(value, term_field, {"identity", "members", "axis_index"})
+        members = term["members"]
+        if not isinstance(members, list):
+            raise ProvenanceSchemaError(f"{term_field}.members must be an array")
+        terms.append(
+            {
+                "identity": _nonempty_string(term["identity"], f"{term_field}.identity"),
+                "members": [
+                    _internal_coordinate(member, f"{term_field}.members[{member_index}]")
+                    for member_index, member in enumerate(members)
+                ],
+                "axis_index": _integer(term["axis_index"], f"{term_field}.axis_index", minimum=0),
+            }
+        )
+    keys = _exact_mapping(entry["keys"], f"{field}.keys", _VALUE_DECOMPOSITION_ROLES)
+    axes = _exact_mapping(entry["axes"], f"{field}.axes", _VALUE_DECOMPOSITION_ROLES)
+    reductions = []
+    for index, value in enumerate(reductions_value):
+        reduction_field = f"{field}.reductions[{index}]"
+        reduction = _exact_mapping(
+            value,
+            reduction_field,
+            {"name", "source_key", "target_key", "reduced_axes"},
+        )
+        reductions.append(
+            {
+                "name": _nonempty_string(reduction["name"], f"{reduction_field}.name"),
+                "source_key": list(_key_path_value(reduction["source_key"], f"{reduction_field}.source_key")),
+                "target_key": list(_key_path_value(reduction["target_key"], f"{reduction_field}.target_key")),
+                "reduced_axes": list(_strings(reduction["reduced_axes"], f"{reduction_field}.reduced_axes")),
+            }
+        )
+    return {
+        "coalition_axis": _nonempty_string(entry["coalition_axis"], f"{field}.coalition_axis"),
+        "feature_axes": list(_strings(entry["feature_axes"], f"{field}.feature_axes")),
+        "terms": terms,
+        "keys": {name: list(_key_path_value(keys[name], f"{field}.keys.{name}")) for name in keys},
+        "axes": {name: list(_strings(axes[name], f"{field}.axes.{name}")) for name in axes},
+        "reductions": reductions,
+        "parameters_shared": _boolean(entry["parameters_shared"], f"{field}.parameters_shared"),
+        "coalition_targets": list(_strings(entry["coalition_targets"], f"{field}.coalition_targets")),
     }
 
 

--- a/src/xdrl/provenance.py
+++ b/src/xdrl/provenance.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from packaging.version import InvalidVersion, Version
 from tdhook.workflow import CompatibilityDecision, PlannedExecution, WorkflowPlan
+from torchrl.data import UnboundedContinuous
 
 from xdrl.compatibility import installed_dependency_versions
 from xdrl.interactions import (
@@ -578,7 +579,16 @@ def _validate_canonical_contract(contract: Mapping[str, Any]) -> None:
     def schema(value: Mapping[str, Any]) -> TensorDictSchema:
         return TensorDictSchema(
             tuple(
-                KeySchema(tuple(item["path"]), KeyRole(item["role"]), KeyPresence(item["presence"]))
+                KeySchema(
+                    tuple(item["path"]),
+                    KeyRole(item["role"]),
+                    KeyPresence(item["presence"]),
+                    (
+                        UnboundedContinuous(shape=tuple(item["feature_shape"]))
+                        if item["feature_shape"] is not None
+                        else None
+                    ),
+                )
                 for item in value["keys"]
             ),
             BatchSemantics(tuple(value["batch_dimensions"])),
@@ -846,8 +856,8 @@ def _value_decomposition_projection(value: Any, field: str) -> dict[str, Any] | 
         reductions.append(
             {
                 "name": _nonempty_string(reduction["name"], f"{reduction_field}.name"),
-                "source_key": list(_key_path_value(reduction["source_key"], f"{reduction_field}.source_key")),
-                "target_key": list(_key_path_value(reduction["target_key"], f"{reduction_field}.target_key")),
+                "source_key": list(_value_key_path(reduction["source_key"], f"{reduction_field}.source_key")),
+                "target_key": list(_value_key_path(reduction["target_key"], f"{reduction_field}.target_key")),
                 "reduced_axes": list(_strings(reduction["reduced_axes"], f"{reduction_field}.reduced_axes")),
             }
         )
@@ -855,12 +865,17 @@ def _value_decomposition_projection(value: Any, field: str) -> dict[str, Any] | 
         "coalition_axis": _nonempty_string(entry["coalition_axis"], f"{field}.coalition_axis"),
         "feature_axes": list(_strings(entry["feature_axes"], f"{field}.feature_axes")),
         "terms": terms,
-        "keys": {name: list(_key_path_value(keys[name], f"{field}.keys.{name}")) for name in keys},
+        "keys": {name: list(_value_key_path(keys[name], f"{field}.keys.{name}")) for name in keys},
         "axes": {name: list(_strings(axes[name], f"{field}.axes.{name}")) for name in axes},
         "reductions": reductions,
         "parameters_shared": _boolean(entry["parameters_shared"], f"{field}.parameters_shared"),
         "coalition_targets": list(_strings(entry["coalition_targets"], f"{field}.coalition_targets")),
     }
+
+
+def _value_key_path(value: Any, field: str) -> tuple[str, ...]:
+    """Normalize a flat TensorDict key before strict provenance validation."""
+    return _key_path_value([value] if isinstance(value, str) else value, field)
 
 
 def _internal_coordinate(value: Any, field: str) -> str | int:

--- a/src/xdrl/types.py
+++ b/src/xdrl/types.py
@@ -44,6 +44,11 @@ class KeyRole(str, Enum):
     LOG_PROBABILITY = "log_probability"
     DISTRIBUTION_PARAMETER = "distribution_parameter"
     VALUE = "value"
+    INDIVIDUAL_VALUE = "individual_value"
+    COALITION_CONTRIBUTION = "coalition_contribution"
+    SEMANTIC_MASK = "semantic_mask"
+    MIXER_INPUT = "mixer_input"
+    JOINT_VALUE = "joint_value"
     FEATURE = "feature"
 
 

--- a/tests/integration/test_provenance.py
+++ b/tests/integration/test_provenance.py
@@ -181,8 +181,8 @@ def test_workflow_provenance_rejects_unknown_revisions_and_fields() -> None:
         WorkflowProvenance.from_dict(payload)
 
     payload = _run().to_dict()
-    payload["schema_revision"] = 3
-    with pytest.raises(ProvenanceSchemaError, match="revision 3 predates internal-computation"):
+    payload["schema_revision"] = 4
+    with pytest.raises(ProvenanceSchemaError, match="revision 4 predates value-decomposition"):
         WorkflowProvenance.from_dict(payload)
 
     payload = _run().to_dict()
@@ -278,6 +278,7 @@ def test_workflow_provenance_decodes_recurrent_and_multi_agent_contract_evidence
         "group": "agents",
         "n_agents": 2,
         "target": {"role": "actor", "selector": {"group": "agents", "agents": [0, "blue"]}},
+        "agent_identities": [],
     }
     restored = WorkflowProvenance.from_dict(payload)
     round_tripped = WorkflowProvenance.from_json(restored.to_json())
@@ -340,6 +341,7 @@ def test_workflow_provenance_strictly_decodes_internal_computation(
                             "role": "actor",
                             "selector": {"group": "other", "agents": []},
                         },
+                        "agent_identities": [],
                     }
                 }
             ),

--- a/tests/integration/test_provenance.py
+++ b/tests/integration/test_provenance.py
@@ -278,7 +278,7 @@ def test_workflow_provenance_decodes_recurrent_and_multi_agent_contract_evidence
         "group": "agents",
         "n_agents": 2,
         "target": {"role": "actor", "selector": {"group": "agents", "agents": [0, "blue"]}},
-        "agent_identities": [],
+        "agent_identities": [0, "blue"],
     }
     restored = WorkflowProvenance.from_dict(payload)
     round_tripped = WorkflowProvenance.from_json(restored.to_json())

--- a/tests/unit/test_value_decomposition.py
+++ b/tests/unit/test_value_decomposition.py
@@ -1,0 +1,310 @@
+import json
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+from tdhook.latent import ActivationCaching
+from tdhook.workflow import Workflow
+from torchrl.data import UnboundedContinuous
+
+from xdrl.interactions import (
+    AgentSelector,
+    CoalitionTerm,
+    InteractionContract,
+    InteractionPhase,
+    InteractionTopology,
+    MultiAgentSemantics,
+    NamedReduction,
+    RuntimeInteractionContext,
+    SemanticTarget,
+    ValueDecompositionAxes,
+    ValueDecompositionKeys,
+    ValueDecompositionSemantics,
+)
+from xdrl.provenance import WorkflowProvenance
+from xdrl.tdhook import TDHookWorkflowRunner
+from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
+
+
+AGENTS = ("alice", "bob", "carol")
+KEYS = ValueDecompositionKeys(
+    individual_value=("agents", "individual_value"),
+    coalition_contribution=("value_decomposition", "coalition_contribution"),
+    semantic_mask=("value_decomposition", "semantic_mask"),
+    mixer_input=("mixer", "state"),
+    joint_value=("mixer", "joint_value"),
+)
+AXES = ValueDecompositionAxes(
+    individual_value=("env", "agent", "value_feature"),
+    coalition_contribution=("env", "coalition", "value_feature"),
+    semantic_mask=("env", "coalition", "agent"),
+    mixer_input=("env", "state_feature"),
+    joint_value=("env", "value_feature"),
+)
+TERMS = (
+    CoalitionTerm("alice", ("alice",), 0),
+    CoalitionTerm("bob", ("bob",), 1),
+    CoalitionTerm("carol", ("carol",), 2),
+    CoalitionTerm("alice+bob", ("alice", "bob"), 3),
+    CoalitionTerm("alice+carol", ("alice", "carol"), 4),
+    CoalitionTerm("bob+carol", ("bob", "carol"), 5),
+    CoalitionTerm("alice+bob+carol", AGENTS, 6),
+)
+REDUCTION = NamedReduction(
+    "sum_coalition_contributions",
+    KEYS.coalition_contribution,
+    KEYS.joint_value,
+    ("coalition",),
+)
+
+
+class _DeterministicCoalitionMixer(torch.nn.Module):
+    """A fixture whose one module serves every semantic agent and coalition."""
+
+    def forward(
+        self,
+        individual_value: torch.Tensor,
+        semantic_mask: torch.Tensor,
+        mixer_input: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        contributions = torch.einsum("eca,eav->ecv", semantic_mask, individual_value)
+        contributions = contributions + mixer_input.sum(dim=-1, keepdim=True).unsqueeze(-2)
+        return contributions, contributions.sum(dim=-2)
+
+
+def _schemas() -> tuple[TensorDictSchema, TensorDictSchema]:
+    batch = BatchSemantics(("env",))
+    return (
+        TensorDictSchema(
+            (
+                KeySchema(
+                    KEYS.individual_value,
+                    KeyRole.INDIVIDUAL_VALUE,
+                    KeyPresence.REQUIRED,
+                    UnboundedContinuous(shape=(len(AGENTS), 1)),
+                ),
+                KeySchema(
+                    KEYS.semantic_mask,
+                    KeyRole.SEMANTIC_MASK,
+                    KeyPresence.REQUIRED,
+                    UnboundedContinuous(shape=(len(TERMS), len(AGENTS))),
+                ),
+                KeySchema(
+                    KEYS.mixer_input,
+                    KeyRole.MIXER_INPUT,
+                    KeyPresence.REQUIRED,
+                    UnboundedContinuous(shape=(2,)),
+                ),
+            ),
+            batch,
+        ),
+        TensorDictSchema(
+            (
+                KeySchema(
+                    KEYS.coalition_contribution,
+                    KeyRole.COALITION_CONTRIBUTION,
+                    KeyPresence.PRODUCED,
+                    UnboundedContinuous(shape=(len(TERMS), 1)),
+                ),
+                KeySchema(
+                    KEYS.joint_value,
+                    KeyRole.JOINT_VALUE,
+                    KeyPresence.PRODUCED,
+                    UnboundedContinuous(shape=(1,)),
+                ),
+            ),
+            batch,
+        ),
+    )
+
+
+def _contract(
+    *,
+    terms: tuple[CoalitionTerm, ...] = TERMS,
+    reductions: tuple[NamedReduction, ...] = (REDUCTION,),
+    axes: ValueDecompositionAxes = AXES,
+) -> InteractionContract:
+    inputs, outputs = _schemas()
+    multi_agent = MultiAgentSemantics(
+        InteractionTopology.MIXER,
+        "agents",
+        len(AGENTS),
+        SemanticTarget(ModelRole.MIXER, AgentSelector("agents", ("alice", "carol"))),
+        agent_identities=AGENTS,
+    )
+    decomposition = ValueDecompositionSemantics(
+        coalition_axis="coalition",
+        feature_axes=("value_feature", "state_feature"),
+        terms=terms,
+        keys=KEYS,
+        axes=axes,
+        reductions=reductions,
+        parameters_shared=True,
+        coalition_targets=tuple(
+            identity
+            for identity in ("alice+carol", "alice+bob+carol")
+            if identity in {term.identity for term in terms}
+        ),
+    )
+    return InteractionContract(
+        identity="shared-mixer:0",
+        role=ModelRole.MIXER,
+        phase=InteractionPhase.EVALUATION,
+        module_path="loss.shared_mixer",
+        input_schema=inputs,
+        output_schema=outputs,
+        agent_dimension="agent",
+        multi_agent=multi_agent,
+        value_decomposition=decomposition,
+    )
+
+
+def test_deterministic_parameter_shared_mixer_preserves_semantic_coalitions() -> None:
+    contract = _contract()
+    module = TensorDictModule(
+        _DeterministicCoalitionMixer(),
+        in_keys=[KEYS.individual_value, KEYS.semantic_mask, KEYS.mixer_input],
+        out_keys=[KEYS.coalition_contribution, KEYS.joint_value],
+    )
+    semantic_mask = torch.tensor(
+        [
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 1, 0],
+            [1, 0, 1],
+            [0, 1, 1],
+            [1, 1, 1],
+        ],
+        dtype=torch.float,
+    ).expand(2, -1, -1)
+    batch = TensorDict(
+        {
+            KEYS.individual_value: torch.tensor([[[1.0], [2.0], [4.0]], [[2.0], [3.0], [5.0]]]),
+            KEYS.semantic_mask: semantic_mask,
+            KEYS.mixer_input: torch.zeros(2, 2),
+        },
+        batch_size=[2],
+    )
+
+    result = RuntimeInteractionContext(contract, module, batch)(batch.clone())
+
+    assert result[KEYS.coalition_contribution][0, :, 0].tolist() == [1, 2, 4, 3, 5, 6, 7]
+    assert result[KEYS.joint_value][:, 0].tolist() == [28, 40]
+    assert contract.module_path == "loss.shared_mixer"
+    assert contract.value_decomposition.parameters_shared
+    assert tuple(term.identity for term in contract.value_decomposition.targeted_terms) == (
+        "alice+carol",
+        "alice+bob+carol",
+    )
+    assert tuple(term.identity for term in contract.value_decomposition.terms) != (contract.module_path,)
+
+
+def test_value_decomposition_is_json_serialisable_without_flattening_keys_or_axes() -> None:
+    encoded = json.loads(json.dumps(_contract().to_dict()))["value_decomposition"]
+
+    assert encoded["terms"][3] == {"identity": "alice+bob", "members": ["alice", "bob"], "axis_index": 3}
+    assert encoded["keys"]["semantic_mask"] == ["value_decomposition", "semantic_mask"]
+    assert encoded["axes"]["coalition_contribution"] == ["env", "coalition", "value_feature"]
+    assert encoded["reductions"][0]["name"] == "sum_coalition_contributions"
+    assert encoded["coalition_targets"] == ["alice+carol", "alice+bob+carol"]
+
+
+def test_named_reduction_and_coalitions_round_trip_in_workflow_provenance() -> None:
+    contract = _contract()
+    module = TensorDictModule(
+        _DeterministicCoalitionMixer(),
+        in_keys=[KEYS.individual_value, KEYS.semantic_mask, KEYS.mixer_input],
+        out_keys=[KEYS.coalition_contribution, KEYS.joint_value],
+    )
+    batch = TensorDict(
+        {
+            KEYS.individual_value: torch.ones(1, len(AGENTS), 1),
+            KEYS.semantic_mask: torch.ones(1, len(TERMS), len(AGENTS)),
+            KEYS.mixer_input: torch.zeros(1, 2),
+        },
+        batch_size=[1],
+    )
+    context = RuntimeInteractionContext(contract, module, batch)
+
+    def coalition_output(output: tuple[torch.Tensor, torch.Tensor], **_kwargs: object) -> torch.Tensor:
+        return output[0]
+
+    execution = TDHookWorkflowRunner(context).run(
+        Workflow(ActivationCaching("module", callback=coalition_output)),
+        batch.clone(),
+        code_revision="test-revision",
+        callback_identifiers={coalition_output: "coalition-output-v1"},
+    )
+    restored = WorkflowProvenance.from_json(execution.provenance.to_json())
+
+    decomposition = restored.interaction_contract["value_decomposition"]
+    assert decomposition["terms"][-1]["members"] == AGENTS
+    assert decomposition["reductions"][0]["reduced_axes"] == ("coalition",)
+
+
+def test_coalition_membership_is_unique_ordered_and_within_the_declared_group() -> None:
+    with pytest.raises(ValueError, match="duplicate agents"):
+        CoalitionTerm("bad", ("alice", "alice"), 0)
+    with pytest.raises(ValueError, match="members must follow declared agent order"):
+        _contract(terms=(CoalitionTerm("bad-order", ("bob", "alice"), 0),))
+    with pytest.raises(ValueError, match="outside the declared group"):
+        _contract(terms=(CoalitionTerm("outsider", ("dave",), 0),))
+    with pytest.raises(ValueError, match="memberships must be unique"):
+        _contract(
+            terms=(
+                CoalitionTerm("first", ("alice",), 0),
+                CoalitionTerm("duplicate", ("alice",), 1),
+            )
+        )
+
+
+def test_implicit_or_misdirected_joint_value_aggregation_is_rejected() -> None:
+    with pytest.raises(ValueError, match="at least one named reduction"):
+        _contract(reductions=())
+    with pytest.raises(ValueError, match="joint_value requires a named reduction"):
+        _contract(
+            reductions=(
+                NamedReduction(
+                    "wrong-axis",
+                    KEYS.semantic_mask,
+                    KEYS.joint_value,
+                    ("agent",),
+                ),
+            )
+        )
+
+
+def test_coalition_axis_is_distinct_and_required_on_coalition_tensors() -> None:
+    colliding = ValueDecompositionSemantics(
+        coalition_axis="agent",
+        feature_axes=("value_feature", "state_feature"),
+        terms=TERMS,
+        keys=KEYS,
+        axes=AXES,
+        reductions=(REDUCTION,),
+        parameters_shared=True,
+        coalition_targets=("alice+carol",),
+    )
+    inputs, outputs = _schemas()
+    multi_agent = MultiAgentSemantics(
+        InteractionTopology.MIXER,
+        "agents",
+        len(AGENTS),
+        SemanticTarget(ModelRole.MIXER, AgentSelector("agents")),
+        agent_identities=AGENTS,
+    )
+
+    with pytest.raises(ValueError, match="distinct from environment, time, agent, and feature"):
+        InteractionContract(
+            "bad-axes",
+            ModelRole.MIXER,
+            InteractionPhase.EVALUATION,
+            "loss.shared_mixer",
+            inputs,
+            outputs,
+            agent_dimension="agent",
+            multi_agent=multi_agent,
+            value_decomposition=colliding,
+        )

--- a/tests/unit/test_value_decomposition.py
+++ b/tests/unit/test_value_decomposition.py
@@ -1,4 +1,6 @@
 import json
+from collections.abc import Callable
+from dataclasses import replace
 
 import pytest
 import torch
@@ -22,7 +24,7 @@ from xdrl.interactions import (
     ValueDecompositionKeys,
     ValueDecompositionSemantics,
 )
-from xdrl.provenance import WorkflowProvenance
+from xdrl.provenance import ProvenanceSchemaError, WorkflowProvenance
 from xdrl.tdhook import TDHookWorkflowRunner
 from xdrl.types import BatchSemantics, KeyPresence, KeyRole, KeySchema, ModelRole, TensorDictSchema
 
@@ -160,6 +162,38 @@ def _contract(
     )
 
 
+def _value_decomposition_provenance() -> WorkflowProvenance:
+    contract = _contract()
+    module = TensorDictModule(
+        _DeterministicCoalitionMixer(),
+        in_keys=[KEYS.individual_value, KEYS.semantic_mask, KEYS.mixer_input],
+        out_keys=[KEYS.coalition_contribution, KEYS.joint_value],
+    )
+    batch = TensorDict(
+        {
+            KEYS.individual_value: torch.ones(1, len(AGENTS), 1),
+            KEYS.semantic_mask: torch.ones(1, len(TERMS), len(AGENTS)),
+            KEYS.mixer_input: torch.zeros(1, 2),
+        },
+        batch_size=[1],
+    )
+    context = RuntimeInteractionContext(contract, module, batch)
+
+    def coalition_output(output: tuple[torch.Tensor, torch.Tensor], **_kwargs: object) -> torch.Tensor:
+        return output[0]
+
+    return (
+        TDHookWorkflowRunner(context)
+        .run(
+            Workflow(ActivationCaching("module", callback=coalition_output)),
+            batch.clone(),
+            code_revision="test-revision",
+            callback_identifiers={coalition_output: "coalition-output-v1"},
+        )
+        .provenance
+    )
+
+
 def test_deterministic_parameter_shared_mixer_preserves_semantic_coalitions() -> None:
     contract = _contract()
     module = TensorDictModule(
@@ -198,7 +232,7 @@ def test_deterministic_parameter_shared_mixer_preserves_semantic_coalitions() ->
         "alice+carol",
         "alice+bob+carol",
     )
-    assert tuple(term.identity for term in contract.value_decomposition.terms) != (contract.module_path,)
+    assert contract.module_path not in {term.identity for term in contract.value_decomposition.terms}
 
 
 def test_value_decomposition_is_json_serialisable_without_flattening_keys_or_axes() -> None:
@@ -212,32 +246,7 @@ def test_value_decomposition_is_json_serialisable_without_flattening_keys_or_axe
 
 
 def test_named_reduction_and_coalitions_round_trip_in_workflow_provenance() -> None:
-    contract = _contract()
-    module = TensorDictModule(
-        _DeterministicCoalitionMixer(),
-        in_keys=[KEYS.individual_value, KEYS.semantic_mask, KEYS.mixer_input],
-        out_keys=[KEYS.coalition_contribution, KEYS.joint_value],
-    )
-    batch = TensorDict(
-        {
-            KEYS.individual_value: torch.ones(1, len(AGENTS), 1),
-            KEYS.semantic_mask: torch.ones(1, len(TERMS), len(AGENTS)),
-            KEYS.mixer_input: torch.zeros(1, 2),
-        },
-        batch_size=[1],
-    )
-    context = RuntimeInteractionContext(contract, module, batch)
-
-    def coalition_output(output: tuple[torch.Tensor, torch.Tensor], **_kwargs: object) -> torch.Tensor:
-        return output[0]
-
-    execution = TDHookWorkflowRunner(context).run(
-        Workflow(ActivationCaching("module", callback=coalition_output)),
-        batch.clone(),
-        code_revision="test-revision",
-        callback_identifiers={coalition_output: "coalition-output-v1"},
-    )
-    restored = WorkflowProvenance.from_json(execution.provenance.to_json())
+    restored = WorkflowProvenance.from_json(_value_decomposition_provenance().to_json())
 
     decomposition = restored.interaction_contract["value_decomposition"]
     assert decomposition["terms"][-1]["members"] == AGENTS
@@ -245,6 +254,8 @@ def test_named_reduction_and_coalitions_round_trip_in_workflow_provenance() -> N
 
 
 def test_coalition_membership_is_unique_ordered_and_within_the_declared_group() -> None:
+    with pytest.raises(TypeError, match="identity must be a string"):
+        CoalitionTerm(5, ("alice",), 0)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="duplicate agents"):
         CoalitionTerm("bad", ("alice", "alice"), 0)
     with pytest.raises(ValueError, match="members must follow declared agent order"):
@@ -274,6 +285,173 @@ def test_implicit_or_misdirected_joint_value_aggregation_is_rejected() -> None:
                 ),
             )
         )
+
+
+def test_implicit_agent_identifiers_reject_strings_and_booleans() -> None:
+    for invalid in ("alice", True):
+        with pytest.raises(ValueError, match="outside the declared group"):
+            MultiAgentSemantics(
+                InteractionTopology.MIXER,
+                "agents",
+                3,
+                SemanticTarget(ModelRole.MIXER, AgentSelector("agents", (invalid,))),
+            )
+
+
+def test_value_axes_require_the_ordered_batch_prefix() -> None:
+    reordered = replace(AXES, individual_value=("agent", "env", "value_feature"))
+
+    with pytest.raises(ValueError, match="must begin with the declared batch dimensions in order"):
+        _contract(axes=reordered)
+
+
+@pytest.mark.parametrize(
+    ("key_name", "shape", "message"),
+    [
+        ("individual_value", (4, 1), "individual_value agent extent must be 3"),
+        ("coalition_contribution", (6, 1), "coalition_contribution coalition extent must be 7"),
+        ("semantic_mask", (7, 4), "semantic_mask agent extent must be 3"),
+    ],
+)
+def test_semantic_axis_extents_match_declared_agents_and_terms(
+    key_name: str, shape: tuple[int, ...], message: str
+) -> None:
+    contract = _contract()
+    schema_name = "output_schema" if key_name == "coalition_contribution" else "input_schema"
+    schema = getattr(contract, schema_name)
+    entries = tuple(
+        replace(entry, spec=UnboundedContinuous(shape=shape)) if entry.key == getattr(KEYS, key_name) else entry
+        for entry in schema.keys
+    )
+
+    with pytest.raises(ValueError, match=message):
+        replace(contract, **{schema_name: replace(schema, keys=entries)})
+
+
+def test_joint_value_reduction_must_start_from_coalition_contributions() -> None:
+    alternate_axes = replace(
+        AXES,
+        semantic_mask=("env", "coalition", "value_feature"),
+    )
+    alternate = NamedReduction(
+        "mask-to-joint",
+        KEYS.semantic_mask,
+        KEYS.joint_value,
+        ("coalition",),
+    )
+
+    with pytest.raises(ValueError, match="from coalition_contribution"):
+        _contract(axes=alternate_axes, reductions=(alternate,))
+
+
+def test_flat_value_decomposition_keys_round_trip_through_provenance() -> None:
+    keys = ValueDecompositionKeys(
+        individual_value="individual_value",
+        coalition_contribution="coalition_contribution",
+        semantic_mask="semantic_mask",
+        mixer_input="mixer_input",
+        joint_value="joint_value",
+    )
+    batch_semantics = BatchSemantics(("env",))
+    inputs = TensorDictSchema(
+        (
+            KeySchema(
+                keys.individual_value,
+                KeyRole.INDIVIDUAL_VALUE,
+                KeyPresence.REQUIRED,
+                UnboundedContinuous(shape=(len(AGENTS), 1)),
+            ),
+            KeySchema(
+                keys.semantic_mask,
+                KeyRole.SEMANTIC_MASK,
+                KeyPresence.REQUIRED,
+                UnboundedContinuous(shape=(len(TERMS), len(AGENTS))),
+            ),
+            KeySchema(
+                keys.mixer_input,
+                KeyRole.MIXER_INPUT,
+                KeyPresence.REQUIRED,
+                UnboundedContinuous(shape=(2,)),
+            ),
+        ),
+        batch_semantics,
+    )
+    outputs = TensorDictSchema(
+        (
+            KeySchema(
+                keys.coalition_contribution,
+                KeyRole.COALITION_CONTRIBUTION,
+                KeyPresence.PRODUCED,
+                UnboundedContinuous(shape=(len(TERMS), 1)),
+            ),
+            KeySchema(
+                keys.joint_value,
+                KeyRole.JOINT_VALUE,
+                KeyPresence.PRODUCED,
+                UnboundedContinuous(shape=(1,)),
+            ),
+        ),
+        batch_semantics,
+    )
+    reduction = NamedReduction(
+        "sum-coalitions",
+        keys.coalition_contribution,
+        keys.joint_value,
+        ("coalition",),
+    )
+    decomposition = ValueDecompositionSemantics(
+        "coalition",
+        ("value_feature", "state_feature"),
+        TERMS,
+        keys,
+        AXES,
+        (reduction,),
+    )
+    multi_agent = MultiAgentSemantics(
+        InteractionTopology.MIXER,
+        "agents",
+        len(AGENTS),
+        SemanticTarget(ModelRole.MIXER, AgentSelector("agents")),
+        agent_identities=AGENTS,
+    )
+    contract = InteractionContract(
+        "flat-keys",
+        ModelRole.MIXER,
+        InteractionPhase.EVALUATION,
+        "loss.shared_mixer",
+        inputs,
+        outputs,
+        agent_dimension="agent",
+        multi_agent=multi_agent,
+        value_decomposition=decomposition,
+    )
+    module = TensorDictModule(
+        _DeterministicCoalitionMixer(),
+        in_keys=[keys.individual_value, keys.semantic_mask, keys.mixer_input],
+        out_keys=[keys.coalition_contribution, keys.joint_value],
+    )
+    data = TensorDict(
+        {
+            keys.individual_value: torch.ones(1, len(AGENTS), 1),
+            keys.semantic_mask: torch.ones(1, len(TERMS), len(AGENTS)),
+            keys.mixer_input: torch.zeros(1, 2),
+        },
+        batch_size=[1],
+    )
+    context = RuntimeInteractionContext(contract, module, data)
+
+    def coalition_output(output: tuple[torch.Tensor, torch.Tensor], **_kwargs: object) -> torch.Tensor:
+        return output[0]
+
+    execution = TDHookWorkflowRunner(context).run(
+        Workflow(ActivationCaching("module", callback=coalition_output)),
+        data,
+        code_revision="test-revision",
+        callback_identifiers={coalition_output: "flat-coalition-output-v1"},
+    )
+    restored = WorkflowProvenance.from_json(execution.provenance.to_json())
+
+    assert restored.interaction_contract["value_decomposition"]["keys"]["joint_value"] == ("joint_value",)
 
 
 def test_coalition_axis_is_distinct_and_required_on_coalition_tensors() -> None:
@@ -308,3 +486,190 @@ def test_coalition_axis_is_distinct_and_required_on_coalition_tensors() -> None:
             multi_agent=multi_agent,
             value_decomposition=colliding,
         )
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: CoalitionTerm("", ("alice",), 0), "identity must be non-empty"),
+        (lambda: CoalitionTerm("empty", (), 0), "membership must be non-empty"),
+        (lambda: CoalitionTerm("bad-member", ("",), 0), "members must be non-empty"),
+        (lambda: CoalitionTerm("bad-index", ("alice",), -1), "axis_index must be"),
+        (lambda: replace(KEYS, joint_value=""), "keys must be non-empty"),
+        (lambda: replace(KEYS, joint_value=KEYS.mixer_input), "keys must be unique"),
+        (lambda: replace(AXES, joint_value=()), "axes must be explicit"),
+        (lambda: replace(AXES, joint_value=("env", "")), "axes must be non-empty"),
+        (lambda: replace(AXES, joint_value=("env", "env")), "axes contain duplicates"),
+        (lambda: NamedReduction("", "source", "target", ("agent",)), "name must be non-empty"),
+        (lambda: NamedReduction("empty", "source", "target", ()), "reduced_axes must be explicit"),
+        (
+            lambda: NamedReduction("duplicate", "source", "target", ("agent", "agent")),
+            "reduced_axes contains duplicates",
+        ),
+        (lambda: NamedReduction("same", "value", "value", ("agent",)), "source and target keys must differ"),
+    ],
+)
+def test_value_decomposition_value_objects_reject_malformed_declarations(
+    factory: Callable[[], object], message: str
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        factory()
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"coalition_axis": ""}, "coalition_axis must be non-empty"),
+        ({"feature_axes": ("",)}, "feature axes must be non-empty and unique"),
+        ({"terms": ()}, "requires coalition terms"),
+        (
+            {
+                "terms": (
+                    CoalitionTerm("same", ("alice",), 0),
+                    CoalitionTerm("same", ("bob",), 1),
+                )
+            },
+            "coalition identities must be unique",
+        ),
+        ({"terms": (CoalitionTerm("offset", ("alice",), 1),)}, "indices must be contiguous"),
+        (
+            {"reductions": (REDUCTION, replace(REDUCTION))},
+            "reduction names must be unique",
+        ),
+        ({"parameters_shared": 1}, "parameters_shared must be a boolean"),
+        ({"coalition_targets": ("alice", "alice")}, "coalition targets must be unique"),
+        ({"coalition_targets": ("unknown",)}, "unknown coalition targets"),
+    ],
+)
+def test_value_decomposition_semantics_reject_invalid_metadata(changes: dict[str, object], message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        replace(_contract().value_decomposition, **changes)
+
+
+def test_empty_coalition_target_selects_every_declared_term() -> None:
+    semantics = replace(_contract().value_decomposition, coalition_targets=())
+
+    assert semantics.targeted_terms == TERMS
+
+
+@pytest.mark.parametrize(
+    ("identities", "selector", "message"),
+    [
+        (("alice", "bob"), (), "must match the declared group size"),
+        (("alice", "alice", "carol"), (), "must be unique"),
+        (("alice", "", "carol"), (), "must be non-empty strings or integers"),
+        (AGENTS, ("outsider",), "outside the declared agent group"),
+    ],
+)
+def test_explicit_agent_identities_are_strictly_validated(
+    identities: tuple[str, ...], selector: tuple[str, ...], message: str
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        MultiAgentSemantics(
+            InteractionTopology.MIXER,
+            "agents",
+            3,
+            SemanticTarget(ModelRole.MIXER, AgentSelector("agents", selector)),
+            agent_identities=identities,
+        )
+
+
+def test_value_decomposition_requires_mixer_and_separate_semantic_axes() -> None:
+    contract = _contract()
+    with pytest.raises(ValueError, match="requires multi-agent semantics"):
+        replace(contract, multi_agent=None)
+    with pytest.raises(ValueError, match="requires a mixer interaction"):
+        replace(contract, multi_agent=replace(contract.multi_agent, topology=InteractionTopology.PARAMETER_SHARED))
+
+    batched_agent = BatchSemantics(("env", "agent"))
+    with pytest.raises(ValueError, match="distinct from leading batch dimensions"):
+        replace(
+            contract,
+            input_schema=replace(contract.input_schema, batch=batched_agent),
+            output_schema=replace(contract.output_schema, batch=batched_agent),
+        )
+    with pytest.raises(ValueError, match="feature axes must be distinct"):
+        replace(
+            contract,
+            value_decomposition=replace(contract.value_decomposition, feature_axes=("env", "value_feature")),
+        )
+
+
+@pytest.mark.parametrize(
+    ("axes", "message"),
+    [
+        (replace(AXES, mixer_input=("env", "unknown")), "declares unknown axes"),
+        (replace(AXES, individual_value=("env", "value_feature")), "must retain the agent dimension"),
+        (replace(AXES, semantic_mask=("env", "agent", "value_feature")), "must retain the coalition axis"),
+    ],
+)
+def test_value_decomposition_rejects_incomplete_axis_semantics(axes: ValueDecompositionAxes, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        _contract(axes=axes)
+
+
+def test_value_decomposition_schema_keys_require_roles_specs_and_matching_rank() -> None:
+    contract = _contract()
+    individual = contract.input_schema.keys[0]
+    without_individual = replace(contract.input_schema, keys=contract.input_schema.keys[1:])
+    with pytest.raises(ValueError, match="individual_value key is not declared"):
+        replace(contract, input_schema=without_individual)
+
+    wrong_role = replace(
+        contract.input_schema, keys=(replace(individual, role=KeyRole.VALUE), *contract.input_schema.keys[1:])
+    )
+    with pytest.raises(ValueError, match="must use the individual_value role"):
+        replace(contract, input_schema=wrong_role)
+
+    missing_spec = replace(
+        contract.input_schema, keys=(replace(individual, spec=None), *contract.input_schema.keys[1:])
+    )
+    with pytest.raises(ValueError, match="requires a spec to validate semantic-axis extents"):
+        replace(contract, input_schema=missing_spec)
+
+    short_axes = replace(AXES, individual_value=("env", "agent"))
+    with pytest.raises(ValueError, match="axes do not match its declared tensor rank"):
+        _contract(axes=short_axes)
+
+
+def test_named_reductions_are_bound_to_declared_keys_and_axis_transformations() -> None:
+    valid = REDUCTION
+    cases = (
+        (
+            NamedReduction("unknown-key", "unknown", KEYS.mixer_input, ("agent",)),
+            "must reference declared value-decomposition keys",
+        ),
+        (
+            NamedReduction("unknown-axis", KEYS.individual_value, KEYS.mixer_input, ("unknown",)),
+            "references unknown axes",
+        ),
+        (
+            NamedReduction("missing-source-axis", KEYS.semantic_mask, KEYS.mixer_input, ("value_feature",)),
+            "axes must exist on its source tensor",
+        ),
+        (
+            NamedReduction("wrong-target-axes", KEYS.individual_value, KEYS.mixer_input, ("agent",)),
+            "target axes must equal its unreduced source axes",
+        ),
+    )
+    for reduction, message in cases:
+        with pytest.raises(ValueError, match=message):
+            _contract(reductions=(valid, reduction))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda value: value.update({"terms": {}}), "terms and.*reductions must be arrays"),
+        (lambda value: value["terms"][0].update({"members": ()}), r"terms\[0\].members must be an array"),
+    ],
+)
+def test_workflow_provenance_strictly_decodes_value_decomposition(
+    mutation: Callable[[dict[str, object]], None], message: str
+) -> None:
+    payload = _value_decomposition_provenance().to_dict()
+    decomposition = payload["interaction_contract"]["value_decomposition"]
+    mutation(decomposition)
+
+    with pytest.raises(ProvenanceSchemaError, match=message):
+        WorkflowProvenance.from_dict(payload)


### PR DESCRIPTION
## Summary

- add semantic coalition terms, explicit tensor axes, nested value-decomposition keys, and named reductions
- validate coalition membership and targeting against ordered agent identities while keeping module identity separate
- enforce ordered TensorDict batch axes, concrete agent/coalition extents, and exact coalition-contribution reductions
- persist the new contract in strict workflow provenance, including flat-key normalization, and bump its schema revision to 5
- cover singleton, pairwise, and higher-order terms with a deterministic parameter-shared mixer fixture

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -q` (284 passed, 95.97% coverage)
- `just check-dependency-snapshot`
- `cd docs && uv run --group docs make html SPHINXOPTS="-W --keep-going"`

Closes #62