### PR TITLE
Restore About page and literature references

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ conformance and documentation gates.
 - [Getting Started](https://xdrl.readthedocs.io/en/latest/start.html)
 - [Tutorials](https://xdrl.readthedocs.io/en/latest/tutorials.html)
 - [API Reference](https://xdrl.readthedocs.io/en/latest/api/index.html)
+- [About](https://xdrl.readthedocs.io/en/latest/about.html)
 
 ## License
 `xdrl` is licensed under the MIT License. See [LICENSE](./LICENSE) for details.

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -6,3 +6,24 @@ model-internal work on TorchRL systems.
 
 TorchRL and TensorDict own RL execution and data. TDHook owns generic PyTorch
 hooks and methods. XDRL owns their validated interaction boundary.
+
+Project links
+-------------
+
+* `Source code <https://github.com/Xmaster6y/xdrl>`_
+* `PyPI package <https://pypi.org/project/xdrl/>`_
+* `MIT License <https://github.com/Xmaster6y/xdrl/blob/main/LICENSE>`_
+
+Literature
+----------
+
+The references below cover the foundations cited by XDRL's public API and the
+papers targeted by its :doc:`reproduction notebooks <tutorials>`. Each
+reproduction notebook separately records the exact paper, reference-code
+revision, asset availability, and limits of the evidence it produces.
+
+References
+----------
+
+.. bibliography::
+   :all:

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,0 +1,8 @@
+About ``xdrl``
+==============
+
+``xdrl`` is an alpha-stage research library for typed, reproducible
+model-internal work on TorchRL systems.
+
+TorchRL and TensorDict own RL execution and data. TDHook owns generic PyTorch
+hooks and methods. XDRL owns their validated interaction boundary.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,8 +19,13 @@ extensions = [
     "sphinx_copybutton",  # Copy button for code blocks
     "sphinx_design",  # Boostrap design components
     "nbsphinx",  # Jupyter notebook support
-    "autoapi.extension",
+    "sphinxcontrib.bibtex",  # BibTeX citation support
+    "autoapi.extension",  # Auto documentation from code
 ]
+
+# BibTeX configuration
+bibtex_bibfiles = ["references.bib"]
+bibtex_default_style = "unsrt"
 
 templates_path = ["_templates"]
 exclude_patterns = []  # type: ignore

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@
     Getting Started <start>
     Tutorials <tutorials>
     API Reference <api/index>
+    About <about>
 
 .. grid:: 1 1 2 2
     :class-container: hero

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -1,0 +1,73 @@
+@misc{bou2023torchrl,
+  title={TorchRL: A data-driven decision-making library for PyTorch},
+  author={Albert Bou and Matteo Bettini and Sebastian Dittert and Vikash Kumar and Shagun Sodhani and Xiaomeng Yang and Gianni De Fabritiis and Vincent Moens},
+  year={2023},
+  eprint={2306.00577},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  url={https://arxiv.org/abs/2306.00577},
+}
+
+@misc{poupart2025tdhook,
+  title={TDHook: A Lightweight Framework for Interpretability},
+  author={Yoann Poupart},
+  year={2025},
+  eprint={2509.25475},
+  archivePrefix={arXiv},
+  primaryClass={cs.AI},
+  url={https://arxiv.org/abs/2509.25475},
+}
+
+@inproceedings{pmlr-v267-soligo25a,
+  title={Inducing, Detecting and Characterising Neural Modules: A Pipeline for Functional Interpretability in Reinforcement Learning},
+  author={Anna Soligo and Pietro Ferraro and David Boyle},
+  booktitle={Proceedings of the 42nd International Conference on Machine Learning},
+  pages={56122--56147},
+  year={2025},
+  volume={267},
+  series={Proceedings of Machine Learning Research},
+  publisher={PMLR},
+  url={https://proceedings.mlr.press/v267/soligo25a.html},
+}
+
+@inproceedings{bush2025interpreting,
+  title={Interpreting Emergent Planning in Model-Free Reinforcement Learning},
+  author={Thomas Bush and Stephen Chung and Usman Anwar and Adri\`a Garriga-Alonso and David Krueger},
+  booktitle={International Conference on Learning Representations},
+  year={2025},
+  url={https://proceedings.iclr.cc/paper_files/paper/2025/hash/cc4d9cfc45325e460b455a820d5f212c-Abstract-Conference.html},
+}
+
+@inproceedings{pmlr-v205-zabounidis23a,
+  title={Concept Learning for Interpretable Multi-Agent Reinforcement Learning},
+  author={Renos Zabounidis and Joseph Campbell and Simon Stepputtis and Dana Hughes and Katia P. Sycara},
+  booktitle={Proceedings of The 6th Conference on Robot Learning},
+  pages={1828--1837},
+  year={2023},
+  volume={205},
+  series={Proceedings of Machine Learning Research},
+  publisher={PMLR},
+  url={https://proceedings.mlr.press/v205/zabounidis23a.html},
+}
+
+@misc{mini2023maze,
+  title={Understanding and Controlling a Maze-Solving Policy Network},
+  author={Ulisse Mini and Peli Grietzer and Mrinank Sharma and Austin Meek and Monte MacDiarmid and Alexander Matt Turner},
+  year={2023},
+  eprint={2310.08043},
+  archivePrefix={arXiv},
+  primaryClass={cs.LG},
+  url={https://arxiv.org/abs/2310.08043},
+}
+
+@inproceedings{pmlr-v202-liu23be,
+  title={{NA2Q}: Neural Attention Additive Model for Interpretable Multi-Agent Q-Learning},
+  author={Zichuan Liu and Yuanyang Zhu and Chunlin Chen},
+  booktitle={Proceedings of the 40th International Conference on Machine Learning},
+  pages={22539--22558},
+  year={2023},
+  volume={202},
+  series={Proceedings of Machine Learning Research},
+  publisher={PMLR},
+  url={https://proceedings.mlr.press/v202/liu23be.html},
+}

--- a/docs/source/reproductions/bixrl-functional-modularity.ipynb
+++ b/docs/source/reproductions/bixrl-functional-modularity.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Reproduce functional neural modules in 2D MiniGrid\n",
     "\n",
-    "**Paper:** [Inducing, Detecting and Characterising Neural Modules](https://proceedings.mlr.press/v267/soligo25a.html) (ICML 2025)  \n",
+    "**Paper:** [Inducing, Detecting and Characterising Neural Modules](https://proceedings.mlr.press/v267/soligo25a.html) (ICML 2025) <cite data-cite=\"pmlr-v267-soligo25a\">(Soligo et al., 2025)</cite>  \n",
     "**Reference code:** [annasoligo/BIXRL](https://github.com/annasoligo/BIXRL/tree/8990ceba70e471926d6cec366d8ce97d8e02fedf) at `8990ceba70e471926d6cec366d8ce97d8e02fedf`  \n",
     "**Target:** `Navix-Dynamic-Obstacles-6x6-Custom-Rand-v0`, 2D only  \n",
     "**Default execution:** bounded synthetic smoke path, not a scientific reproduction  \n",

--- a/docs/source/reproductions/emergent-planning-sokoban.ipynb
+++ b/docs/source/reproductions/emergent-planning-sokoban.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Reproduce emergent planning in Sokoban\n",
     "\n",
-    "**Paper:** [Interpreting Emergent Planning in Model-Free Reinforcement Learning](https://proceedings.iclr.cc/paper_files/paper/2025/hash/cc4d9cfc45325e460b455a820d5f212c-Abstract-Conference.html) (ICLR 2025)  \n",
+    "**Paper:** [Interpreting Emergent Planning in Model-Free Reinforcement Learning](https://proceedings.iclr.cc/paper_files/paper/2025/hash/cc4d9cfc45325e460b455a820d5f212c-Abstract-Conference.html) (ICLR 2025) <cite data-cite=\"bush2025interpreting\">(Bush et al., 2025)</cite>  \n",
     "**Project page:** [Model-Free Planning](https://tuphs28.github.io/projects/interpplanning/)  \n",
     "**Target:** one DRC(3,3) Sokoban checkpoint, with 3 ConvLSTM layers and 3 exact internal ticks per environment step  \n",
     "**Default execution:** bounded synthetic smoke path, not a scientific reproduction  \n",

--- a/docs/source/reproductions/marl-concept-policy.ipynb
+++ b/docs/source/reproductions/marl-concept-policy.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Expert-concept policies in a simulated MARL task\n",
     "\n",
-    "This notebook is a scoped reproduction of Zabounidis et al., [*Concept Learning for Interpretable Multi-Agent Reinforcement Learning*](https://proceedings.mlr.press/v205/zabounidis23a.html) (CoRL 2022 / PMLR 205, 2023), limited to one simulated cooperative-competitive task.\n",
+    "This notebook is a scoped reproduction of [*Concept Learning for Interpretable Multi-Agent Reinforcement Learning*](https://proceedings.mlr.press/v205/zabounidis23a.html) (CoRL 2022 / PMLR 205, 2023) <cite data-cite=\"pmlr-v205-zabounidis23a\">(Zabounidis et al., 2023)</cite>, limited to one simulated cooperative-competitive task.\n",
     "\n",
     "**Current evidence:** deterministic smoke-fixture training, held-out metrics, matched-control accounting, typed TensorDict intervention mechanics, and artifact provenance only. **The paper result is not evaluated.**\n",
     "\n",

--- a/docs/source/reproductions/maze-policy-goal-representations.ipynb
+++ b/docs/source/reproductions/maze-policy-goal-representations.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Reproduce goal representations and steering in Procgen Maze\n",
     "\n",
-    "**Paper:** [Understanding and Controlling a Maze-Solving Policy Network](https://arxiv.org/abs/2310.08043v1) (arXiv v1, 12 October 2023)  \n",
+    "**Paper:** [Understanding and Controlling a Maze-Solving Policy Network](https://arxiv.org/abs/2310.08043v1) (arXiv v1, 12 October 2023) <cite data-cite=\"mini2023maze\">(Mini et al., 2023)</cite>  \n",
     "**Reference code:** [`UlisseMini/procgen-tools@dc2243c99110aca92687cdf566daafcfbe7067a0`](https://github.com/UlisseMini/procgen-tools/tree/dc2243c99110aca92687cdf566daafcfbe7067a0)  \n",
     "**Target policy:** `maze_I/model_rand_region_5.pth`, IMPALA scale 15, `procgen==0.10.7`  \n",
     "**Target layer:** `embedder.block2.res1.resadd_out`  \n",

--- a/docs/source/reproductions/na2q-value-decomposition.ipynb
+++ b/docs/source/reproductions/na2q-value-decomposition.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Reproduce NA2Q on one cooperative MARL task\n",
     "\n",
-    "**Paper:** [NA2Q: Neural Attention Additive Model for Interpretable Multi-Agent Q-Learning](https://proceedings.mlr.press/v202/liu23be.html) (ICML 2023)  \n",
+    "**Paper:** [NA2Q: Neural Attention Additive Model for Interpretable Multi-Agent Q-Learning](https://proceedings.mlr.press/v202/liu23be.html) (ICML 2023) <cite data-cite=\"pmlr-v202-liu23be\">(Liu et al., 2023)</cite>  \n",
     "**Reference code:** [zichuan-liu/NA2Q](https://github.com/zichuan-liu/NA2Q/tree/adc10b43bd2677179cb3e0f09bebd703e9debf9f) at `adc10b43bd2677179cb3e0f09bebd703e9debf9f`  \n",
     "**Target:** Level-Based Foraging `lbf-4-2` (4 agents, 2 food, 10x10 grid, 5x5 local view)  \n",
     "**Default execution:** bounded deterministic smoke fixture, not a scientific reproduction  \n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ docs = [
     "sphinx-charts>=0.2.1",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.6.1",
+    "sphinxcontrib-bibtex>=2.6.5",
 ]
 
 [build]

--- a/src/xdrl/semantics.py
+++ b/src/xdrl/semantics.py
@@ -142,6 +142,9 @@ class InternalOccurrenceSelection:
 class InternalComputationSemantics:
     """Serializable semantic axes and their exact per-root-call hook mapping.
 
+    Repeated internal computation is important in analyses of recurrent RL
+    agents such as :cite:`bush2025interpreting`.
+
     Environment time and sequence/burn-in remain owned by
     :class:`InteractionContract` and :class:`RecurrentSemantics`. These axes
     name only repeated computation inside one root model call. ``occurrences``
@@ -356,7 +359,12 @@ class NamedReduction:
 
 @dataclass(frozen=True, slots=True)
 class ValueDecompositionSemantics:
-    """Coalition identities, tensor axes, keys, and explicit aggregations."""
+    """Coalition identities, tensor axes, keys, and explicit aggregations.
+
+    The explicit coalition, identity, attention, and semantic-mask fields can
+    represent interpretable additive decompositions such as NA2Q
+    :cite:`pmlr-v202-liu23be` without implementing their learning algorithm.
+    """
 
     coalition_axis: str
     feature_axes: tuple[str, ...]

--- a/src/xdrl/tdhook.py
+++ b/src/xdrl/tdhook.py
@@ -234,7 +234,7 @@ class PairedWorkflowExecutionError(RuntimeError):
 
 @dataclass(slots=True)
 class TDHookWorkflowRunner:
-    """Delegate TDHook v0.2 workflow planning and execution through XDRL."""
+    """Delegate TDHook :cite:`poupart2025tdhook` workflow execution through XDRL."""
 
     interaction: RuntimeInteractionContext
 

--- a/src/xdrl/types.py
+++ b/src/xdrl/types.py
@@ -1,8 +1,9 @@
 """TorchRL-native contracts for RL model roles and TensorDict schemas.
 
-The types in this module describe interfaces around TorchRL objects.  They do
-not introduce a container or a spec hierarchy: data remains a
-``TensorDictBase`` and value constraints remain TorchRL ``TensorSpec`` objects.
+The types in this module describe interfaces around TorchRL
+:cite:`bou2023torchrl` objects. They do not introduce a container or a spec
+hierarchy: data remains a ``TensorDictBase`` and value constraints remain
+TorchRL ``TensorSpec`` objects.
 """
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -671,6 +671,15 @@ wheels = [
 ]
 
 [[package]]
+name = "latexcodec"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/dd/4270b2c5e2ee49316c3859e62293bd2ea8e382339d63ab7bbe9f39c0ec3b/latexcodec-3.0.1.tar.gz", hash = "sha256:e78a6911cd72f9dec35031c6ec23584de6842bfbc4610a9678868d14cdfb0357", size = 31222, upload-time = "2025-06-17T18:47:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/40/23569737873cc9637fd488606347e9dd92b9fa37ba4fcda1f98ee5219a97/latexcodec-3.0.1-py3-none-any.whl", hash = "sha256:a9eb8200bff693f0437a69581f7579eb6bca25c4193515c09900ce76451e452e", size = 18532, upload-time = "2025-06-17T18:47:30.726Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1290,6 +1299,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pybtex"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "latexcodec" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f5/f30da9c93f0fa6d619332b2f69597219b625f35780473a05164a9981fd9a/pybtex-0.26.1.tar.gz", hash = "sha256:2e5543bea424e60e9e42eef70bff597be48649d8f68ba061a7a092b2477d5464", size = 692991, upload-time = "2026-04-03T13:05:39.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/f6/775eb92e865b28cdb4ad1f2bed7a5446197516f76b58a950faa3be3fd08d/pybtex-0.26.1-py3-none-any.whl", hash = "sha256:e26c0412cc54f5f21b2a6d9d175762a2d2af9ccf3a8f651cdb89ec035db77aa1", size = 126134, upload-time = "2026-04-03T13:05:40.623Z" },
+]
+
+[[package]]
+name = "pybtex-docutils"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "pybtex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/84/796ea94d26188a853660f81bded39f8de4cfe595130aef0dea1088705a11/pybtex-docutils-1.0.3.tar.gz", hash = "sha256:3a7ebdf92b593e00e8c1c538aa9a20bca5d92d84231124715acc964d51d93c6b", size = 18348, upload-time = "2023-08-22T18:47:54.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/b1/ce1f4596211efb5410e178a803f08e59b20bedb66837dcf41e21c54f9ec1/pybtex_docutils-1.0.3-py3-none-any.whl", hash = "sha256:8fd290d2ae48e32fcb54d86b0efb8d573198653c7e2447d5bec5847095f430b9", size = 6385, upload-time = "2023-08-22T06:43:20.513Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1704,6 +1739,21 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinxcontrib-bibtex"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "pybtex" },
+    { name = "pybtex-docutils" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/6a/8e0b2c2420286389e7fed78ff361ec30e2f1d58c8560af8d64df5e7b61e0/sphinxcontrib_bibtex-2.7.0.tar.gz", hash = "sha256:fee700f7aae29bb8f654c62913f00d34ac44fc0b8ca0fa67ac922ff4453addee", size = 120669, upload-time = "2026-05-06T09:29:24.935Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/c0/d28e62407f4733bbe0169287bc012f0ac3b4a2021066b285570654119c8b/sphinxcontrib_bibtex-2.7.0-py3-none-any.whl", hash = "sha256:28cf0ec7a957d1c7548d5749317ed472ce877e1b629f430f88e3789aa51f87b1", size = 40287, upload-time = "2026-05-06T09:29:23.253Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-devhelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2047,6 +2097,7 @@ docs = [
     { name = "sphinx-charts" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
+    { name = "sphinxcontrib-bibtex" },
 ]
 
 [package.metadata]
@@ -2077,6 +2128,7 @@ docs = [
     { name = "sphinx-charts", specifier = ">=0.2.1" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- restore the documentation About page removed during the docs simplification
- add About back to the Sphinx navigation and README
- adopt TDHook's central BibTeX/Sphinx citation pipeline
- list the literature targeted by all five reproduction notebooks
- add explicit rendered citations beside the paper header in every reproduction notebook
- link literature-backed public API concepts to the generated bibliography

## Citation scope

- every reproduction notebook retains its exact paper and reference-code links and now cites its paper through the shared bibliography
- `InternalComputationSemantics` cites the recurrent-agent analysis it supports
- `ValueDecompositionSemantics` cites NA2Q while explicitly stating that XDRL does not implement its learning algorithm
- `TDHookWorkflowRunner` and the TorchRL-native type boundary cite their upstream foundations
- no XDRL project citation is invented because XDRL does not currently have a project paper

## Validation

- `just docs` (warning-strict; executes all tutorials and reproductions)
- verified citations on all five rendered reproduction pages link to their About bibliography entries
- verified all 7 BibTeX entries render on About and API citations link back to them
- `uv run pre-commit run --all-files`
- `git diff --check`