### PR TITLE
Fix dev docs version selector

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,9 @@ release = xdrl.__version__
 # If READTHEDOCS_VERSION doesn't exist, we're not on RTD
 # If it is an integer, we're in a PR build and the version isn't correct.
 # If it's "latest" → change to "dev"
-if not version_match or version_match.isdigit() or version_match == "latest":
+if version_match == "latest":
+    version_match = "dev"
+elif not version_match or version_match.isdigit():
     # For local development, infer the version to match from the package.
     if "dev" in release or "rc" in release:
         version_match = "dev"


### PR DESCRIPTION
## Summary

- map the Read the Docs `latest` build to the `dev` switcher entry
- retain package-version inference for local and pull request builds
- match the version-selection behavior used by lczerolens

## Validation

- `uv run pre-commit run --files docs/source/conf.py`
- `READTHEDOCS_VERSION=latest uv run sphinx-build -W --keep-going -b html docs/source /tmp/xdrl-docs-version-build`
- verified the generated HTML sets `theme_switcher_version_match` to `dev`