### PR TITLE
Docs: lead quickstart with activation capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,33 +28,42 @@ pip install xdrl
 import torch
 from tensordict import TensorDict
 from tensordict.nn import TensorDictModule
-from xdrl import Interaction
+from tdhook.latent import ActivationCaching
+from tdhook.workflow import Workflow
+from xdrl import Interaction, run_workflow
 
-batch = TensorDict(
-    {"observation": torch.randn(8, 4)},
-    batch_size=[8],
-    names=["env"],
-)
 policy = TensorDictModule(
-    torch.nn.Linear(4, 2),
+    torch.nn.Sequential(
+        torch.nn.Linear(4, 8),
+        torch.nn.Tanh(),
+        torch.nn.Linear(8, 2),
+    ),
     in_keys=["observation"],
     out_keys=["action"],
 )
+batch = TensorDict(
+    {"observation": torch.randn(8, 4)},
+    batch_size=[8],
+)
 interaction = Interaction(policy)
+workflow = Workflow(
+    ActivationCaching("module.1", cache_key=("activations", "hidden"))
+)
+execution = run_workflow(interaction, workflow, batch)
 
-result = interaction(batch)
-assert result["action"].shape == (8, 2)
+assert execution.data["action"].shape == (8, 2)
+assert execution.data["activations", "hidden", "module.1"].shape == (8, 8)
 ```
 
-The TensorDict's native `batch_size` and dimension names describe its batch.
-The module's native `in_keys`, `out_keys`, and TorchRL specs remain the source
-of truth. For model-internal observation and intervention, pass the same
-interaction to `xdrl.run_workflow`; TDHook remains the owner of targets, hooks,
-planning, and cleanup.
+TorchRL and TensorDict own policy execution, keys, specs, and batched data.
+TDHook owns the model-internal method: here, capturing the hidden activation.
+XDRL validates those boundaries and connects the policy to the workflow through
+`Interaction` and `run_workflow`. An activation capture records an internal
+value; by itself, it is not evidence that the activation causally affects the
+policy's action.
 
-For recurrent TorchRL modules, `RecurrentSemantics.from_torchrl(...)` maps
-their native `next` state outputs and `is_init` reset key without introducing
-another recurrent module abstraction.
+For recurrent TorchRL modules, see `RecurrentSemantics` in the
+[API reference](https://xdrl.readthedocs.io/en/latest/api/index.html).
 
 ## Development
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-Install XDRL and construct one boundary around an unchanged TorchRL module:
+Install XDRL, run a small TorchRL policy, and capture one hidden activation:
 
 .. code-block:: bash
 
@@ -12,65 +12,39 @@ Install XDRL and construct one boundary around an unchanged TorchRL module:
    import torch
    from tensordict import TensorDict
    from tensordict.nn import TensorDictModule
-   from xdrl import Interaction
+   from tdhook.latent import ActivationCaching
+   from tdhook.workflow import Workflow
+   from xdrl import Interaction, run_workflow
 
    policy = TensorDictModule(
-       torch.nn.Linear(4, 2),
+       torch.nn.Sequential(
+           torch.nn.Linear(4, 8),
+           torch.nn.Tanh(),
+           torch.nn.Linear(8, 2),
+       ),
        in_keys=["observation"],
        out_keys=["action"],
    )
-   interaction = Interaction(policy)
    batch = TensorDict(
        {"observation": torch.randn(8, 4)},
        batch_size=[8],
-       names=["env"],
    )
-
-   result = interaction(batch)
-   assert result["action"].shape == (8, 2)
-
-The TorchRL module remains the source of truth for keys and specs. XDRL only
-adds semantic checks that the upstream objects do not express. For example,
-TorchRL recurrent modules can use their native ``next`` and ``is_init``
-conventions directly:
-
-.. code-block:: python
-
-   from torchrl.modules import LSTMModule
-   from xdrl import RecurrentSemantics
-
-   recurrent_policy = LSTMModule(
-       input_size=4,
-       hidden_size=8,
-       in_key="observation",
-       out_key="embedding",
+   interaction = Interaction(policy)
+   workflow = Workflow(
+       ActivationCaching("module.1", cache_key=("activations", "hidden"))
    )
-   recurrent = RecurrentSemantics.from_torchrl(
-       "recurrent_state_h",
-       "recurrent_state_c",
-   )
-   recurrent_interaction = Interaction(
-       recurrent_policy,
-       recurrent,
-   )
+   execution = run_workflow(interaction, workflow, batch)
 
-TDHook workflows
-----------------
+   assert execution.data["action"].shape == (8, 2)
+   assert execution.data["activations", "hidden", "module.1"].shape == (8, 8)
 
-``run_workflow`` is the only XDRL workflow entrypoint. It validates the
-caller's Torch state against TDHook's public plan, delegates execution to
-TDHook, and returns TDHook's native ``WorkflowResult``:
+TorchRL and TensorDict own policy execution, keys, specs, and batched data.
+TDHook owns the model-internal method: here, capturing the hidden activation.
+XDRL validates those boundaries and connects the policy to the workflow through
+``Interaction`` and ``run_workflow``. An activation capture records an internal
+value; by itself, it is not evidence that the activation causally affects the
+policy's action.
 
-.. code-block:: python
-
-   from tdhook.latent import ActivationCaching
-   from tdhook.workflow import Workflow
-   from xdrl import run_workflow
-
-   workflow = Workflow(ActivationCaching("module"))
-   execution = run_workflow(interaction, workflow, batch.clone())
-
-   assert execution.plan.model_passes == 1
-
-Use TDHook ``Target`` and ``HookSession`` directly for model-internal captures,
-replacements, gradients, and repeated-call occurrence selection.
+For recurrent TorchRL modules, see
+:class:`xdrl.interactions.RecurrentSemantics`. For richer model-internal
+workflows, continue with :doc:`tutorials`.

--- a/tests/integration/test_quickstart.py
+++ b/tests/integration/test_quickstart.py
@@ -1,0 +1,32 @@
+import pytest
+import torch
+from tdhook.latent import ActivationCaching
+from tdhook.workflow import Workflow
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from xdrl import Interaction, run_workflow
+
+
+@pytest.mark.integration
+def test_quickstart_captures_hidden_activation() -> None:
+    policy = TensorDictModule(
+        torch.nn.Sequential(
+            torch.nn.Linear(4, 8),
+            torch.nn.Tanh(),
+            torch.nn.Linear(8, 2),
+        ),
+        in_keys=["observation"],
+        out_keys=["action"],
+    )
+    batch = TensorDict(
+        {"observation": torch.randn(8, 4)},
+        batch_size=[8],
+    )
+    interaction = Interaction(policy)
+    workflow = Workflow(ActivationCaching("module.1", cache_key=("activations", "hidden")))
+
+    execution = run_workflow(interaction, workflow, batch)
+
+    assert execution.data["action"].shape == (8, 2)
+    assert execution.data["activations", "hidden", "module.1"].shape == (8, 8)


### PR DESCRIPTION
## Summary

- lead the README and documentation quickstarts with the same CPU-only multi-layer TorchRL policy
- run `ActivationCaching` through XDRL and assert both action and hidden-activation shapes
- explain the TorchRL/TensorDict, TDHook, and XDRL ownership boundary without implying causal evidence
- add a focused integration smoke test for the documented flow

## Validation

- `uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -q` (19 passed, 96.30% coverage)
- `uv run --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`
- `uv run pre-commit run --all-files`

Closes #79