### PR TITLE
docs: group notebooks by learning intent

### DIFF
--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,18 +1,12 @@
 Tutorials and reproductions
 ===========================
 
-Choose a path based on what you want to learn. If you are new to XDRL, begin
-with the feature guides and follow them in order. Complete workflows combine
-several features into a realistic investigation, while scientific
-reproductions evaluate claims from published work with their own provenance,
-controls, evidence status, and claim limits.
+Choose a notebook based on what you want to learn.
 
 Feature guides
 --------------
 
-These focused notebooks introduce one XDRL boundary or capability at a time,
-progressing from an unchanged policy interaction to model-internal observation
-and intervention.
+Learn one XDRL capability at a time, in the suggested order.
 
 .. grid:: 1 2 2 2
    :gutter: 3
@@ -48,8 +42,7 @@ and intervention.
 Complete workflows
 ------------------
 
-These task-oriented notebooks combine multiple capabilities into an end-to-end
-policy investigation.
+Follow an end-to-end policy investigation that combines multiple capabilities.
 
 .. grid:: 1 2 2 2
    :gutter: 3
@@ -64,9 +57,7 @@ policy investigation.
 Scientific reproductions
 ------------------------
 
-These paper-specific notebooks keep scientific evaluation distinct from
-product tutorials. Each reproduction states its provenance, controls, evidence
-status, and the limits of the claims it can support.
+Evaluate published work with explicit provenance, controls, and claim limits.
 
 .. grid:: 1 2 2 2
    :gutter: 3

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,6 +1,19 @@
 Tutorials and reproductions
 ===========================
 
+Choose a path based on what you want to learn. If you are new to XDRL, begin
+with the feature guides and follow them in order. Complete workflows combine
+several features into a realistic investigation, while scientific
+reproductions evaluate claims from published work with their own provenance,
+controls, evidence status, and claim limits.
+
+Feature guides
+--------------
+
+These focused notebooks introduce one XDRL boundary or capability at a time,
+progressing from an unchanged policy interaction to model-internal observation
+and intervention.
+
 .. grid:: 1 2 2 2
    :gutter: 3
 
@@ -32,12 +45,31 @@ Tutorials and reproductions
 
       Apply a focused TDHook intervention through an XDRL interaction.
 
+Complete workflows
+------------------
+
+These task-oriented notebooks combine multiple capabilities into an end-to-end
+policy investigation.
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+
    .. grid-item-card:: End-to-end investigation
       :link: notebooks/end-to-end-policy-investigation
       :link-type: doc
       :class-card: surface
 
       Run matched diagnosis and intervention workflows on one policy.
+
+Scientific reproductions
+------------------------
+
+These paper-specific notebooks keep scientific evaluation distinct from
+product tutorials. Each reproduction states its provenance, controls, evidence
+status, and the limits of the claims it can support.
+
+.. grid:: 1 2 2 2
+   :gutter: 3
 
    .. grid-item-card:: BiXRL functional modularity
       :link: reproductions/bixrl-functional-modularity
@@ -78,8 +110,8 @@ Tutorials and reproductions
    :hidden:
 
    notebooks/collection.ipynb
-   notebooks/internal-computation.ipynb
    notebooks/workflow-evidence.ipynb
+   notebooks/internal-computation.ipynb
    notebooks/intervention.ipynb
    notebooks/end-to-end-policy-investigation.ipynb
    reproductions/bixrl-functional-modularity.ipynb


### PR DESCRIPTION
## Summary

- add a starting guide for choosing among feature guides, complete workflows, and scientific reproductions
- group every existing notebook into exactly one visible section without changing notebook paths
- align the hidden toctree with the feature-guide learning progression

## Validation

- `git diff --check`
- `uv run sphinx-build -W --keep-going -b html docs/source docs/build/html`

Closes #80