### PR TITLE
Use released TDHook 0.2.1

### DIFF
--- a/docs/source/notebooks/internal-computation.ipynb
+++ b/docs/source/notebooks/internal-computation.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "policy = TensorDictModule(ReusedLayer(), in_keys=[\"observation\"], out_keys=[\"action\"])\n",
     "interaction = Interaction(policy)\n",
-    "target = Target(\"module.shared\", \"activation\", -1, (0,), occurrence=1)\n",
+    "target = Target(\"module.shared\", \"activation\", -1, (0,), occurrences=(1,))\n",
     "workflow = Workflow(ActivationCaching(target, cache_key=(\"activations\", \"selected\")))\n",
     "data = TensorDict({\"observation\": torch.tensor([[1.0, 2.0]])}, batch_size=[1])\n",
     "result = run_workflow(interaction, workflow, data)\n",

--- a/docs/source/reproductions/emergent-planning-sokoban.ipynb
+++ b/docs/source/reproductions/emergent-planning-sokoban.ipynb
@@ -255,7 +255,7 @@
     "for tick in range(3):\n",
     "    for layer in range(3):\n",
     "        path = f\"module.cells.{layer}\"\n",
-    "        target = Target(path, \"activation\", 1, tuple(range(channels)), occurrence=tick)\n",
+    "        target = Target(path, \"activation\", 1, tuple(range(channels)), occurrences=(tick,))\n",
     "        cache_methods.append(ActivationCaching(target, cache_key=(\"internal\", f\"layer-{layer}\", f\"tick-{tick}\")))\n",
     "trace_result = run_workflow(interaction, Workflow(*cache_methods), batch.clone())\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "tdhook @ git+https://github.com/Xmaster6y/tdhook@bb85c69b0d678205d5e534dfe6253fdf0a820eff",
+    "tdhook==0.2.1",
     "tensordict>=0.13,<0.14",
     "torch>=2.11",
     "torchrl>=0.13,<0.14",
@@ -63,7 +63,6 @@ build-backend = "setuptools.build_meta"
 default-groups = ["dev", "docs"]
 
 [tool.uv.sources]
-tdhook = { git = "https://github.com/Xmaster6y/tdhook", branch = "main" }
 tensordict = { git = "https://github.com/pytorch/tensordict" }
 # TorchRL main currently selects nightly CPU wheels on macOS Python 3.11/3.13;
 # mirror that upstream split until its source policy is unified.

--- a/skills/xdrl-library/SKILL.md
+++ b/skills/xdrl-library/SKILL.md
@@ -26,7 +26,7 @@ provenance format, trainer, data container, or paired-experiment subsystem.
 1. Wrap the existing module once with `Interaction`.
 2. Call the interaction directly for a normal TorchRL invocation.
 3. Call `run_workflow(interaction, workflow, data)` for a TDHook workflow.
-4. Use TDHook `Target(occurrence=...)` or `HookSession` directly for repeated
+4. Use TDHook `Target(occurrences=(...,))` or `HookSession` directly for repeated
    model-internal calls.
 
 TensorDict's `batch_size` and dimension names describe the batch. The module's

--- a/tests/integration/test_library_skill.py
+++ b/tests/integration/test_library_skill.py
@@ -54,5 +54,5 @@ def test_library_skill_describes_the_current_public_boundary() -> None:
     skill = SKILL.read_text()
 
     assert "run_workflow(interaction, workflow, data)" in skill
-    assert "Target(occurrence=...)" in skill
+    assert "Target(occurrences=(...,))" in skill
     assert "TDHook's native `WorkflowResult`" in skill

--- a/tests/integration/test_tdhook_workflow.py
+++ b/tests/integration/test_tdhook_workflow.py
@@ -55,7 +55,7 @@ def test_run_workflow_returns_tdhooks_native_result() -> None:
 @pytest.mark.integration
 def test_tdhook_owns_repeated_occurrence_selection() -> None:
     interaction = _interaction()
-    target = Target("module.shared", "activation", -1, (0,), occurrence=1)
+    target = Target("module.shared", "activation", -1, (0,), occurrences=(1,))
     workflow = Workflow(ActivationCaching(target, cache_key=("activations", "selected")))
     data = TensorDict({"observation": torch.tensor([[1.0, 2.0]])}, batch_size=[1])
 

--- a/uv.lock
+++ b/uv.lock
@@ -1826,12 +1826,16 @@ wheels = [
 
 [[package]]
 name = "tdhook"
-version = "0.2.0"
-source = { git = "https://github.com/Xmaster6y/tdhook?branch=main#bb85c69b0d678205d5e534dfe6253fdf0a820eff" }
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tensordict" },
     { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'" },
     { name = "torch", version = "2.14.0.dev20260805", source = { registry = "https://download.pytorch.org/whl/nightly/cpu" }, marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/2f/5b6d081df2c5a0c5ab4bc1246083878db6610108869f3fc3ae8250ccfb56/tdhook-0.2.1.tar.gz", hash = "sha256:012f4a5f84ba869f21a508031efc0159267fd4475af83470dd16932f2c315fe8", size = 135865, upload-time = "2026-09-03T19:02:12.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/20/78c0ba511abd7789c8dc044c9f54523d5d98e3e9bea1624da1ac6c603f2d/tdhook-0.2.1-py3-none-any.whl", hash = "sha256:ebc81f8d56a1aa53a8ff9b6ea60b1c21adfd307e9198f49a0059f156a4fec400", size = 114223, upload-time = "2026-09-03T19:02:10.769Z" },
 ]
 
 [[package]]
@@ -2101,7 +2105,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "tdhook", git = "https://github.com/Xmaster6y/tdhook?branch=main" },
+    { name = "tdhook", specifier = "==0.2.1" },
     { name = "tensordict", git = "https://github.com/pytorch/tensordict" },
     { name = "torch", marker = "python_full_version == '3.12.*' or sys_platform != 'darwin'", specifier = ">=2.11", index = "https://pypi.org/simple" },
     { name = "torch", marker = "python_full_version != '3.12.*' and sys_platform == 'darwin'", specifier = ">=2.11", index = "https://download.pytorch.org/whl/nightly/cpu" },


### PR DESCRIPTION
## Summary

- require exactly `tdhook==0.2.1` from the package index
- remove the TDHook Git source override and revision pin
- update repeated-call examples and conformance coverage to TDHook 0.2.1’s `occurrences` API

## Validation

- `uv lock --check`
- `uv run pytest -q` (19 passed)
- `uv run pre-commit run --all-files`
- `uv run sphinx-build -W -b html docs/source build/docs`
- `uv build`

Closes #51